### PR TITLE
Change WeatherProvider to singleton & bug fix

### DIFF
--- a/app/services/mf.ts
+++ b/app/services/mf.ts
@@ -96,7 +96,7 @@ export class MFProvider extends WeatherProvider {
         const d = {
             time: dayStartTime,
             description: dailyForecast.daily_weather_description == null ? '' : dailyForecast.daily_weather_description,
-            icon: dailyForecast.daily_weather_icon == null ? '01d' : convertMFICon(dailyForecast.daily_weather_icon),
+            icon: dailyForecast.daily_weather_icon == null ? '01d' : this.convertMFICon(dailyForecast.daily_weather_icon),
             temperatureMax: Math.round(dailyForecast.T_max),
             temperatureMin: Math.round(dailyForecast.T_min),
             humidity: (dailyForecast.relative_humidity_max + dailyForecast.relative_humidity_min) / 2,

--- a/app/services/weather.d.ts
+++ b/app/services/weather.d.ts
@@ -1,3 +1,5 @@
+type ProviderType = 'meteofrance' | 'openweathermap' | 'openmeteo';
+
 interface WeatherData {
     currently: Currently;
     daily: Daily;

--- a/app/services/weatherprovider.ts
+++ b/app/services/weatherprovider.ts
@@ -1,6 +1,18 @@
 import { WeatherLocation } from "./api";
 
 export abstract class WeatherProvider {
+    private static _singleton: WeatherProvider;
+    private static _singletonProviderType: ProviderType;
+
     abstract getWeather(weatherLocation: WeatherLocation);
+
+    public static setInstance(newSingleton: WeatherProvider, singletonType: ProviderType): void {
+        WeatherProvider._singleton = newSingleton;
+        WeatherProvider._singletonProviderType = singletonType;
+    }
+
+    public static getInstance(): [WeatherProvider, ProviderType] {
+        return [WeatherProvider._singleton, WeatherProvider._singletonProviderType];
+    }
 }
 

--- a/app/services/weatherproviderfactory.ts
+++ b/app/services/weatherproviderfactory.ts
@@ -6,9 +6,17 @@ import { getString } from '@nativescript/core/application-settings';
 
 
 export function getProvider(): WeatherProvider {
-    const providerString: 'meteofrance' | 'openweathermap' | 'openmeteo' = getString('provider', 'meteofrance') as any;
+    const requestedProviderType: ProviderType = getString('provider', 'meteofrance') as any;
+    let [ provider, providerType ] = WeatherProvider.getInstance();
+    if (requestedProviderType != providerType) {
+        provider = setProvider(requestedProviderType);
+    }
+    return provider;
+}
+
+function setProvider(newType: ProviderType): WeatherProvider {
     let provider: WeatherProvider;
-    switch(providerString) {
+    switch(newType) {
         case 'openmeteo':
             provider = new OMProvider(); 
             break;
@@ -21,5 +29,6 @@ export function getProvider(): WeatherProvider {
             provider = new MFProvider(); 
             break;
     }
+    WeatherProvider.setInstance(provider, newType);
     return provider;
 }


### PR DESCRIPTION
#59 introduced a bug where convertMFICon was moved to MFProvider but was still accessed as if not a method
Edit: Include 8cc1b24. It does not really make sense to have multiple weather providers at once