### PR TITLE
add de locale to fastlane and improve formatting for en+fr

### DIFF
--- a/fastlane/metadata/android/de/full_description.txt
+++ b/fastlane/metadata/android/de/full_description.txt
@@ -1,0 +1,3 @@
+Dies ist eine Open Source App, um auf detaillierte Wetterdaten von OpenWeatherMap zuzugreifen.
+
+Sie können einen kostenlosen OWM-Schlüssel erstellen, um auf Wetterdaten zuzugreifen. In der App ist ein Standardschlüssel enthalten, aber der Zugriff ist eingeschränkt, und es können Fehler im Zusammenhang mit der Ratenbegrenzung auftreten.

--- a/fastlane/metadata/android/de/short_description.txt
+++ b/fastlane/metadata/android/de/short_description.txt
@@ -1,0 +1,1 @@
+Greifen Sie über die öffentlichen OpenWeatherMap-Daten auf Wetterdaten zu

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,3 +1,5 @@
 Open Source app to access detailed weather data from OpenWeather, Open-Meteo and Meteo France. Weather radar provided by RainViewer.
+
 You can create a free OWM key to access OpenWeather weather data.
+
 There is a default key included in the app but the access is limited and you could get errors related to rate limits.

--- a/fastlane/metadata/android/fr-FR/full_description.txt
+++ b/fastlane/metadata/android/fr-FR/full_description.txt
@@ -1,3 +1,5 @@
 Application Open Source pour accéder aux données météorologiques détaillées d'OpenWeather, Open-Meteo et Meteo France. Radar météorologique fourni par RainViewer.
+
 Vous pouvez créer une clé OWM gratuite pour accéder aux données météorologiques.
+
 Il y a une clé par défaut incluse dans l'application, mais l'accès est limité et vous pouvez obtenir des erreurs liées à la limite de taux.


### PR DESCRIPTION
Just found we hat the de locale for oss-weather at IzzyOnDroid, but it's missing here – you I thought you'd like to have it. While on it, I also updated the other 2 full descriptions: just added 2 empty lines, so they also render nicely as Markdown while still being compatible with systems not supporting that.