### PR TITLE
fix(android/gadgetbridge): guard missing sun/moon events breaking the broadcast

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -28,9 +28,13 @@ Applies to EVERY task, including ad-hoc debugging.
 ## Verification
 
 - Non-trivial changes require verification. The user should specify how (a Vitest test, `svelte-check`, eslint, manual run); if unspecified, propose a method and confirm.
-- Unit tests run via **Vitest**: `yarn test` (all tests, CI-equivalent) or `yarn test:watch`. Isolate with `npx vitest run <path>` or `-t '<name>'`; `yarn vitest` fails on Yarn 4, so use `npx` for the binary. Config lives in [`vitest.config.ts`](../vitest.config.ts) + [`vitest.setup.ts`](../vitest.setup.ts); tests are `app/**/*.test.ts` and run on every pull request via [`.github/workflows/unit-tests.yml`](../.github/workflows/unit-tests.yml).
-- Writing tests: import the **real** production function — never re-declare its logic (a regex, a format string) inside the test, or the test passes while the app breaks. `vitest.setup.ts` mocks the NativeScript runtime and native plugins, and `vitest.config.ts` mirrors the webpack `DefinePlugin` globals and the `.common.ts` platform resolution; add to those when a module fails to import. `ApplicationSettings` is an in-memory store that resets between tests, so settings-dependent behaviour can be seeded with `ApplicationSettings.setX`. `TZ` is pinned to UTC because filename/date formatting is timezone sensitive.
-- Modules that transitively import the NativeScript UI layer (e.g. `app/models/OCRDocument.ts`) cannot be imported under Vitest; extract the pure logic into a sibling module — as done for `app/services/sync/folderFilter.ts` and `app/utils/exportUtils.ts` — and test that.
+- **Red to green, always.** Any change whose logic a unit test can reach gets its test **written first and observed failing** — a bug fix starts with a test reproducing the bug, a feature starts with a test of the behaviour it adds. Watch the red run and check it fails on the assertion (an import error means the test is broken, not the code), then write the code until it goes green. Test and code go in the same commit.
+    - A test added on code that already works has nothing to be red against: break the code, watch it go red, revert the break.
+    - Testability is a design constraint. When the logic would be trapped in a `.svelte` file or a module importing the NativeScript runtime, extract the pure part into a sibling module — that is what makes it testable, and it is usually the better structure anyway.
+    - Genuinely untestable (UI layout, native-only path, device behaviour)? Say so explicitly and name the manual check instead. Never skip the test silently.
+- Unit tests run via **Vitest**: `yarn test` or `yarn test:watch`. Isolate with `npx vitest run <path>` or `-t '<name>'`; `yarn vitest` fails on Yarn 4, so use `npx` for the binary. Config is [`vitest.config.mts`](../vitest.config.mts) (`~`/`@shared` aliases, node environment); tests are `app/**/*.test.ts`. There is no CI workflow running them yet.
+- Writing tests: import the **real** production function — never re-declare its logic (a regex, a format string) inside the test, or the test passes while the app breaks.
+- There is no NativeScript runtime mock: a module that imports the UI layer, a native plugin, or a webpack `DefinePlugin` global cannot be imported under Vitest. Extract the pure logic into a sibling module — as done for [`app/utils/slider.ts`](../app/utils/slider.ts) — and test that. Add a `vitest.setup.ts` with the needed mocks when a test genuinely requires one.
 - Types/Svelte: `yarn svelte-check` (this one is a real package.json script). Lint: `npx eslint <files>` (flat config).
 - UI/behavioral changes: run the app on device/emulator — `ns run ios` / `ns run android` (the repo also ships `yarn run.ios.production` / `yarn run.android.production`). This needs the git submodules + native toolchain (see `Readme.md` "Building Setup"), so it is heavy; when a native run isn't possible, state that a visual check is still required.
 - Trivial changes (typos, comments) can skip formal verification.
@@ -47,6 +51,13 @@ Beyond those:
 - Prefer `const`/`let`, never `var`.
 - NEVER use a single-letter variable name — always prefer an explicit name.
 - Avoid `!` (non-null assertion) and `as SomeType` casts (`as const` is fine). Use type guards, narrowing, or restructured types instead.
+
+## Native APIs
+
+When app code touches a native Android API, **ALWAYS** check it is declared, and add it to the `whitelist` of [`App_Resources/Android/native-api-usage.json`](../App_Resources/Android/native-api-usage.json) when it is not — in the same commit as the code using it. The metadata generator only keeps declared APIs, so a missing entry is not a build error: it is an `undefined` at runtime, on device only.
+
+- **Check first, add only what is missing.** `@akylas/nativescript` already declares most of the common surface (`android.view:View`, `ViewParent`, `android.graphics:Rect`, `android.os:Build.VERSION`, `java.util:ArrayList`, …) in `node_modules/@akylas/nativescript/platforms/android/native-api-usage.json`; plugins ship their own lists and `whitelist-plugins-usages: true` pulls them in. Grep those before adding anything — a redundant entry is noise.
+- One entry per class, `package:Class`, nested classes spelled out separately (`android.view:WindowInsets.Type` is not covered by `android.view:WindowInsets`).
 
 ## Repo layout
 

--- a/.claude/skills/feat/SKILL.md
+++ b/.claude/skills/feat/SKILL.md
@@ -36,7 +36,7 @@ What's lifted, vs interactive build:
 Verification & failure (the unattended safety core):
 
 - **Green gate** — before opening the PR, the relevant `npx vitest run <path>` is green, `yarn svelte-check` is clean, and `npx eslint <changed files>` passes. Loop commits still require green tests first.
-- **Mutation-smoke every test you write** — break the code under test; the test must go red, then **revert the mutation** (committing mutated code unattended ships a broken build). A green test that asserts nothing fakes the safety net; judge by mutations caught, never coverage %.
+- **Red before green** — every test is written before the code it covers and observed failing first (Phase 6). For a test added on **pre-existing** code there is nothing to be red against, so mutation-smoke it instead: break the code under test, watch it go red, then **revert the mutation** (committing mutated code unattended ships a broken build). A green test that asserts nothing fakes the safety net; judge by failures caught, never coverage %.
 - **Adversarial review** — run the review subagent (Phase 8), fix criticals yourself, note the rest in the PR.
 - **Self-repair while it converges** — review rejects or the green gate won't pass → fix and retry. Keep going as long as **each round clears a distinct new failure** (real progress) — no fixed retry cap. Stop the moment a round **repeats a failure or makes no progress** (spinning, not converging) → **do not open a PR**: post a comment on the GitHub issue (`gh issue comment`) with the reason (no issue → report it in the run output), then stop. **Never push red, never open a failing PR, never loop on the same failure.**
 - **Stop at the draft PR** — `open-pr` opens a draft; lead the body with a **⚠️ banner** listing each recorded assumption ("observed behavior, assumed intended — to confirm") and a **🐞 Suspected bugs** section. Never mark it ready or merge.
@@ -134,16 +134,20 @@ Wrap the long sections (Impacted files, Steps, Test strategy) in `<details><summ
 
 ## Phase 5: Test plan — _build only_
 
-Define the testing strategy before implementing. Check for missing tests on the touched code and propose to write them where a unit is testable in isolation (services/utils/transformers are the natural fit; `.svelte` UI is verified by running). Present a test-plan table (Vitest unit scenario + file; any manual check); user confirms. Tests are written in Phase 6 alongside the code. _Auto: define the plan and proceed without confirmation._
+Define the testing strategy before implementing. Check for missing tests on the touched code and propose to write them where a unit is testable in isolation (services/utils/transformers are the natural fit; `.svelte` UI is verified by running). Present a test-plan table (Vitest unit scenario + file; any manual check); user confirms. Tests are written in Phase 6, **red first**. _Auto: define the plan and proceed without confirmation._
+
+**Testability is part of the design, not an afterthought.** When the new behaviour would only live inside a `.svelte` file or a module that imports the NativeScript runtime, plan the pure part as a sibling module (`app/utils/`, `app/services/…`) so a test can reach it — as `app/utils/slider.ts` does for `RangeSlider.svelte`. Say so explicitly in the plan when a chunk is genuinely untestable and will be covered by a manual check instead.
 
 ## Phase 6: Implement & verify — _build only_
 
 **Precondition**: a plan exists (auto needs only this); interactive additionally requires it grilled and user-approved — the long grill-me interview is the most common place this gets dropped, so if you can't point to an approved plan, finish Phase 3 first.
 
-Core loop (repeat for each commit from the Phase 3 plan):
+Core loop (repeat for each commit from the Phase 3 plan), **red → green**:
 
-1. Write implementation code + Vitest tests for ONE logical chunk.
-2. Run `npx vitest run <path>` — must stay green. Tests breaking → fix before continuing. Run `yarn svelte-check` when `.svelte`/typing is touched.
+1. For ONE logical chunk: write the Vitest test **first**, run `npx vitest run <path>` and watch it **fail for the expected reason** (assertion, not an import error — an import error means the test is broken, not the code). Then write the implementation until it goes green. Tests and code land in the same commit.
+    - This replaces the mutation-smoke step for new code: a test that was red before the code existed has already proven it asserts something.
+    - When the chunk is genuinely untestable (`.svelte` UI, native-only path), say so in the step summary and name the manual check instead — do not silently skip.
+2. Run `npx vitest run <path>` — the whole file must be green, not just the new test. Run `yarn svelte-check` when `.svelte`/typing is touched.
 3. **STOP before committing — even for a one-file change.** Mandatory, not optional, never skip. List changed files, summarize, say: "Step N done. Please review in your editor and confirm when ready to commit." Do NOT commit without explicit approval. _Auto: skip steps 3-4 — mutation-smoke any test written (break code → red → revert), then once tests are green commit directly and continue._
 4. Once the user confirms → commit via the `commit` skill.
 

--- a/.claude/skills/fix/SKILL.md
+++ b/.claude/skills/fix/SKILL.md
@@ -183,6 +183,9 @@ Types to consider: **Patch** (guard clause, null check), **Structural** (fix the
 
 ## Phase 10: Implement & verify — _build only_
 
+- **Reproduce the bug as a failing test first, whenever the root cause is reachable from a unit test.** Write the test against the confirmed hypothesis, run `npx vitest run <path>`, and watch it go **red for the right reason** — that red run is what proves the diagnosis and, later, that the fix is what turned it green. Only then apply the fix. Test and fix land in the same commit.
+    - Not reachable (the cause lives in a `.svelte` cell, a native call, a device-only path)? Say so explicitly and fall back to the manual repro steps — but first check whether the pure part can be extracted to a sibling module (as `app/utils/slider.ts` is for `RangeSlider.svelte`), which is usually the better fix anyway.
+    - Same for each spread instance: one test case per instance when they are testable.
 - Apply the chosen fix; fix **all** spread instances; implement prevention tasks; mark tasks completed.
 - Verify the bug is resolved and tests pass (`npx vitest run <path>`; `yarn svelte-check` when `.svelte`/typing is touched).
 - **STOP before committing — even for a one-file change.** Mandatory, not optional. List changed files, summarize, say: "Fix ready. Please review in your editor and confirm when ready to commit." Do NOT commit without explicit approval. Never skip this.

--- a/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/App_Resources/Android/src/main/AndroidManifest.xml
@@ -33,6 +33,10 @@
         <intent>
             <action android:name="android.intent.action.MAIN" />
         </intent>
+        <!-- Gadgetbridge WeatherSpec -->
+        <intent>
+            <action android:name="nodomain.freeyourgadget.gadgetbridge.ACTION_GENERIC_WEATHER" />
+        </intent>
     </queries>
     <application android:requestLegacyExternalStorage="true"
         android:name="com.tns.NativeScriptApplication" android:allowBackup="true"

--- a/App_Resources/Android/src/main/java/com/akylas/weather/gadgetbridge/GadgetbridgeService.kt
+++ b/App_Resources/Android/src/main/java/com/akylas/weather/gadgetbridge/GadgetbridgeService.kt
@@ -4,222 +4,65 @@ import android.content.Context
 import android.content.Intent
 import android.util.Log
 import org.json.JSONArray
-import org.json.JSONObject
 import java.io.ByteArrayOutputStream
 import java.util.zip.GZIPOutputStream
 import kotlin.concurrent.thread
 
 /**
  * Gadgetbridge Service for broadcasting weather data to smartwatches
- * Implements the Gadgetbridge weather protocol with JSON + GZIP compression
+ * The WeatherSpec payload is built in JS (see app/services/gadgetbridgePayload.ts), this only
+ * compresses it and broadcasts it to every known Gadgetbridge variant
  */
 class GadgetbridgeService {
     companion object {
         private const val TAG = "GadgetbridgeService"
         private const val ACTION = "nodomain.freeyourgadget.gadgetbridge.ACTION_GENERIC_WEATHER"
-        
+
+        // https://gadgetbridge.org/internals/development/weather-support/
+        private val PACKAGES = listOf(
+            "nodomain.freeyourgadget.gadgetbridge",
+            "nodomain.freeyourgadget.gadgetbridge.nightly",
+            "nodomain.freeyourgadget.gadgetbridge.nightly_nopebble",
+            "com.espruino.gadgetbridge.banglejs",
+            "com.espruino.gadgetbridge.banglejs.nightly"
+        )
+
         /**
          * Broadcast weather data to Gadgetbridge on a background thread
          * @param context Android context
-         * @param weatherDataJson Weather data as JSON string
-         * @param locationJson Location data as JSON string
+         * @param weatherSpecsJson JSON array of WeatherSpec objects
          */
         @JvmStatic
-        fun broadcastWeather(context: Context, weatherDataJson: String, locationJson: String) {
+        fun broadcastWeather(context: Context, weatherSpecsJson: String) {
             // Run on background thread to avoid blocking main thread
             thread {
                 try {
-                    val weatherData = JSONObject(weatherDataJson)
-                    val location = JSONObject(locationJson)
-                    
-                    // Build Gadgetbridge data array (Gadgetbridge expects an array even for single location)
-                    val gadgetbridgeDataArray = JSONArray()
-                    val gadgetbridgeData = buildGadgetbridgeData(weatherData, location)
-                    gadgetbridgeDataArray.put(gadgetbridgeData)
-                    
-                    // Compress with GZIP - send as array
-                    val weatherGz = gzipCompress(gadgetbridgeDataArray.toString())
-                    
-                    // Send broadcast
-                    // val intent = Intent(ACTION)
-                    // intent.putExtra("WeatherGz", weatherGz)
-                    // intent.putExtra("WeatherJson", gadgetbridgeData.toString())
-                    // intent.setFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES)
-                    val packages = listOf(
-                        "nodomain.freeyourgadget.gadgetbridge",
-                        "nodomain.freeyourgadget.gadgetbridge.nightly"
-                    )
-                    val gadgetbridgeDataString = gadgetbridgeData.toString()
-                    packages.forEach { pkg ->
+                    val weatherSpecs = JSONArray(weatherSpecsJson)
+                    if (weatherSpecs.length() == 0) {
+                        return@thread
+                    }
+
+                    // current format: the whole array, gzipped
+                    val weatherGz = gzipCompress(weatherSpecs.toString())
+                    // deprecated format, kept for older Gadgetbridge versions: the first location only
+                    val weatherJson = weatherSpecs.getJSONObject(0).toString()
+
+                    PACKAGES.forEach { pkg ->
                         val intent = Intent(ACTION).apply {
                             setPackage(pkg)
+                            // Gadgetbridge may be in the stopped state, it would not be woken up otherwise
+                            addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES)
                             putExtra("WeatherGz", weatherGz)
-                            putExtra("WeatherJson", gadgetbridgeDataString)
+                            putExtra("WeatherJson", weatherJson)
                         }
                         context.sendBroadcast(intent)
                     }
-                    
-                    
-                    // Log.d(TAG, "Weather data broadcasted to Gadgetbridge: ${gadgetbridgeData.optString("location")}")
                 } catch (e: Exception) {
                     Log.e(TAG, "Failed to broadcast weather to Gadgetbridge", e)
                 }
             }
         }
-        
-        /**
-         * Build Gadgetbridge-compatible JSON from weather data
-         */
-        private fun buildGadgetbridgeData(weatherData: JSONObject, location: JSONObject): JSONObject {
-            val result = JSONObject()
-            
-            try {
-                val currently = weatherData.optJSONObject("currently")
-                val daily = weatherData.optJSONObject("daily")?.optJSONArray("data")
-                val hourly = weatherData.optJSONArray("hourly")
-                
-                // Timestamp (seconds)
-                result.put("timestamp", (weatherData.optLong("time", 0) / 1000).toInt())
-                
-                // Location
-                result.put("location", location.optString("name", ""))
-                
-                // Current weather
-                currently?.let { current ->
-                    result.put("currentTemp", kelvinFromCelsius(current.optDouble("temperature", 0.0)))
-                    result.put("currentConditionCode", current.optInt("iconId", 3200))
-                    result.put("currentCondition", current.optString("description", ""))
-                    result.put("currentHumidity", current.optInt("relativeHumidity", 0))
-                    result.put("windSpeed", current.optDouble("windSpeed", 0.0).toFloat())
-                    result.put("windDirection", current.optInt("windBearing", 0))
-                    result.put("uvIndex", current.optDouble("uvIndex", 0.0).toFloat())
-                    result.put("feelsLikeTemp", kelvinFromCelsius(current.optDouble("apparentTemperature", 0.0)))
-                    result.put("dewPoint", kelvinFromCelsius(current.optDouble("dewpoint", 0.0)))
-                    result.put("pressure", current.optDouble("sealevelPressure", 0.0).toFloat())
-                    result.put("cloudCover", current.optInt("cloudCover", 0))
-                    
-                    // Add air quality data if available
-                    addAirQualityData(result, current)
-                }
-                
-                // Today's min/max from first daily entry
-                if (daily != null && daily.length() > 0) {
-                    val today = daily.getJSONObject(0)
-                    result.put("todayMaxTemp", kelvinFromCelsius(today.optDouble("temperatureMax", 0.0)))
-                    result.put("todayMinTemp", kelvinFromCelsius(today.optDouble("temperatureMin", 0.0)))
-                    result.put("precipProbability", today.optInt("precipProbability", 0))
-                    result.put("sunRise", (today.optLong("sunriseTime", 0) / 1000).toInt())
-                    result.put("sunSet", (today.optLong("sunsetTime", 0) / 1000).toInt())
-                    result.put("moonRise", (today.optLong("moonRise", 0) / 1000).toInt())
-                    result.put("moonSet", (today.optLong("moonSet", 0) / 1000).toInt())
-                    result.put("moonPhase", today.optInt("moonPhase", 0))
-                }
-                
-                // Daily forecasts (skip first day, include up to 7 days)
-                if (daily != null && daily.length() > 1) {
-                    val forecasts = JSONArray()
-                    val maxForecasts = minOf(daily.length(), 8) // First + 7 more
-                    for (i in 1 until maxForecasts) {
-                        val day = daily.getJSONObject(i)
-                        val forecast = JSONObject()
-                        forecast.put("conditionCode", day.optInt("iconId", 3200))
-                        forecast.put("maxTemp", kelvinFromCelsius(day.optDouble("temperatureMax", 0.0)))
-                        forecast.put("minTemp", kelvinFromCelsius(day.optDouble("temperatureMin", 0.0)))
-                        forecast.put("humidity", day.optInt("relativeHumidity", 0))
-                        forecast.put("windSpeed", day.optDouble("windSpeed", 0.0).toFloat())
-                        forecast.put("windDirection", day.optInt("windBearing", 0))
-                        forecast.put("uvIndex", day.optDouble("uvIndex", 0.0).toFloat())
-                        forecast.put("precipProbability", day.optInt("precipProbability", 0))
-                        forecast.put("sunRise", (day.optLong("sunriseTime", 0) / 1000).toInt())
-                        forecast.put("sunSet", (day.optLong("sunsetTime", 0) / 1000).toInt())
-                        forecast.put("moonRise", (day.optLong("moonRise", 0) / 1000).toInt())
-                        forecast.put("moonSet", (day.optLong("moonSet", 0) / 1000).toInt())
-                        forecast.put("moonPhase", day.optInt("moonPhase", 0))
-                        
-                        // Add air quality data for daily forecast if available
-                        addAirQualityData(forecast, day)
-                        
-                        forecasts.put(forecast)
-                    }
-                    result.put("forecasts", forecasts)
-                }
-                
-                // Hourly forecasts
-                if (hourly != null && hourly.length() > 0) {
-                    val hourlyForecasts = JSONArray()
-                    for (i in 0 until minOf(hourly.length(), 48)) { // Up to 48 hours
-                        val hour = hourly.getJSONObject(i)
-                        val hourForecast = JSONObject()
-                        hourForecast.put("timestamp", (hour.optLong("time", 0) / 1000).toInt())
-                        hourForecast.put("temp", kelvinFromCelsius(hour.optDouble("temperature", 0.0)))
-                        hourForecast.put("conditionCode", hour.optInt("iconId", 3200))
-                        hourForecast.put("humidity", hour.optInt("relativeHumidity", 0))
-                        hourForecast.put("windSpeed", hour.optDouble("windSpeed", 0.0).toFloat())
-                        hourForecast.put("windDirection", hour.optInt("windBearing", 0))
-                        hourForecast.put("uvIndex", hour.optDouble("uvIndex", 0.0).toFloat())
-                        hourForecast.put("precipProbability", hour.optInt("precipProbability", 0))
-                        hourlyForecasts.put(hourForecast)
-                    }
-                    result.put("hourly", hourlyForecasts)
-                }
-                
-            } catch (e: Exception) {
-                Log.e(TAG, "Error building Gadgetbridge data", e)
-            }
-            
-            return result
-        }
-        
-        /**
-         * Add air quality data to result object if available
-         */
-        private fun addAirQualityData(result: JSONObject, data: JSONObject) {
-            // Check if AQI is available
-            val aqi = data.optInt("aqi", -1)
-            if (aqi > 0) {
-                val airQuality = JSONObject()
-                airQuality.put("aqi", aqi)
-                
-                // Get pollutants if available
-                val pollutants = data.optJSONObject("pollutants")
-                pollutants?.let { p ->
-                    // CO (convert from mg/m³ to µg/m³ if needed, or use as is)
-                    p.optJSONObject("co")?.let { co ->
-                        airQuality.put("co", co.optDouble("value", 0.0).toFloat())
-                    }
-                    // NO2 (µg/m³)
-                    p.optJSONObject("no2")?.let { no2 ->
-                        airQuality.put("no2", no2.optDouble("value", 0.0).toFloat())
-                    }
-                    // O3 (µg/m³)
-                    p.optJSONObject("o3")?.let { o3 ->
-                        airQuality.put("o3", o3.optDouble("value", 0.0).toFloat())
-                    }
-                    // PM10 (µg/m³)
-                    p.optJSONObject("pm10")?.let { pm10 ->
-                        airQuality.put("pm10", pm10.optDouble("value", 0.0).toFloat())
-                    }
-                    // PM2.5 (µg/m³)
-                    p.optJSONObject("pm2_5")?.let { pm25 ->
-                        airQuality.put("pm25", pm25.optDouble("value", 0.0).toFloat())
-                    }
-                    // SO2 (µg/m³)
-                    p.optJSONObject("so2")?.let { so2 ->
-                        airQuality.put("so2", so2.optDouble("value", 0.0).toFloat())
-                    }
-                }
-                
-                result.put("airQuality", airQuality)
-            }
-        }
-        
-        /**
-         * Convert Celsius to Kelvin (rounded to int)
-         */
-        private fun kelvinFromCelsius(celsius: Double): Int {
-            return (celsius + 273.15).toInt()
-        }
-        
+
         /**
          * Compress string data using GZIP
          */

--- a/app/helpers/formatter.ts
+++ b/app/helpers/formatter.ts
@@ -1,6 +1,6 @@
 import addressFormatter from '@akylas/address-formatter';
 import { Color } from '@nativescript/core';
-import { getMoonIllumination } from 'suncalc';
+import { getMoonPhase } from '~/helpers/moon';
 import { colorForAqi, colorForPollen, colorForPollutant } from '~/services/airQualityData';
 import { WeatherLocation } from '~/services/api';
 import type { CommonAirQualityData, Currently, DailyData, Hourly } from '~/services/providers/weather';
@@ -402,11 +402,7 @@ export function getMoonPhaseName(age: number) {
 //     return Math.floor(age);
 // }
 
-export function getMoonPhase(date: Date) {
-    const illumination = getMoonIllumination(date);
-    // const phase = calculateMoon(date.getFullYear(), date.getMonth(), date.getDate(), date.getHours(), date.getMinutes(), date.getSeconds());
-    return Math.round(illumination.phase * 28);
-}
+export { getMoonPhase };
 export function moonIcon(moonPhase: number, coord: { lat: number; lon: number }) {
     if (coord.lat < 0) {
         moonPhase = 29 - moonPhase;

--- a/app/helpers/moon.ts
+++ b/app/helpers/moon.ts
@@ -1,0 +1,17 @@
+import { getMoonIllumination } from 'suncalc';
+
+/**
+ * Moon phase as the app icon index: 0..28.
+ */
+export function getMoonPhase(date: Date) {
+    const illumination = getMoonIllumination(date);
+    return Math.round(illumination.phase * 28);
+}
+
+/**
+ * Moon phase in degrees [0, 360[, the unit Gadgetbridge's WeatherSpec expects.
+ */
+export function getMoonPhaseDegrees(date: Date) {
+    const illumination = getMoonIllumination(date);
+    return Math.round(illumination.phase * 360) % 360;
+}

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -131,6 +131,7 @@
   "freezing_rain": "Freezing rain",
   "french": "French",
   "full": "full",
+  "gadgetbridge_broadcast_failed": "Could not send weather data to Gadgetbridge",
   "gadgetbridge_disabled_msg": "Gadgetbridge disabled",
   "gadgetbridge_enabled_msg": "Gadgetbridge enabled",
   "gadgetbridge_enabled": "Enable Gadgetbridge support",

--- a/app/services/gadgetbridge.ts
+++ b/app/services/gadgetbridge.ts
@@ -1,18 +1,19 @@
-import { Application, ApplicationSettings, Utils } from '@nativescript/core';
+import { ApplicationSettings, Utils } from '@nativescript/core';
+import { lc } from '@nativescript-community/l';
+import { showError } from '@shared/utils/showError';
 import { WeatherLocation } from './api';
+import { buildGadgetbridgePayload } from './gadgetbridgePayload';
 import { WeatherData } from './providers/weather';
-import { getMoonTimes, getTimes } from 'suncalc';
-import dayjs from 'dayjs';
-import { getMoonPhase } from '~/helpers/formatter';
 
 const GADGETBRIDGE_ENABLED_KEY = 'gadgetbridge_enabled';
 
 /**
  * Gadgetbridge Service for broadcasting weather data to smartwatches
- * Delegates to native Kotlin implementation for JSON encoding and broadcasting
+ * The payload is built in `gadgetbridgePayload`; the native Kotlin side only gzips and broadcasts it
  */
 class GadgetbridgeService {
     private enabled = false;
+    private failureReported = false;
 
     constructor() {
         this.enabled = ApplicationSettings.getBoolean(GADGETBRIDGE_ENABLED_KEY, false);
@@ -23,6 +24,7 @@ class GadgetbridgeService {
      */
     setEnabled(enabled: boolean) {
         this.enabled = enabled;
+        this.failureReported = false;
         ApplicationSettings.setBoolean(GADGETBRIDGE_ENABLED_KEY, enabled);
     }
 
@@ -43,34 +45,20 @@ class GadgetbridgeService {
 
         try {
             const context = Utils.android.getApplicationContext();
-
-            // we need to add sun/moon data
-            const toSendData = JSON.parse(JSON.stringify(weatherData)) as WeatherData;
-            toSendData.daily?.data.forEach((d) => {
-                const date = dayjs.utc(d.time);
-                const times = getTimes(date as any, location.coord.lat, location.coord.lon);
-                const moontimes = getMoonTimes(date as any, location.coord.lat, location.coord.lon);
-                d.sunsetTime = dayjs.utc(times.sunsetStart.valueOf()).valueOf();
-                d.sunriseTime = dayjs.utc(times.sunriseEnd.valueOf()).valueOf();
-                d['moonRise'] = dayjs.utc(moontimes.rise.valueOf()).valueOf();
-                if (moontimes.set) {
-                    d['moonSet'] = dayjs.utc(moontimes.set.valueOf()).valueOf();
-                }
-                d['moonPhase'] = getMoonPhase(date as any);
-            });
-            // Convert weather data and location to JSON strings
-            const weatherDataJson = JSON.stringify(toSendData);
-            const locationJson = JSON.stringify(location);
-            DEV_LOG && console.log('locationJson', locationJson);
-            DEV_LOG && console.log('weatherDataJson', weatherDataJson);
+            const weatherSpecsJson = JSON.stringify(buildGadgetbridgePayload(location, weatherData));
+            DEV_LOG && console.log('[Gadgetbridge] weatherSpecsJson', weatherSpecsJson);
 
             // Call native Kotlin method to handle broadcasting on background thread
             const GadgetbridgeServiceClass = com.akylas.weather.gadgetbridge.GadgetbridgeService;
-            GadgetbridgeServiceClass.broadcastWeather(context, weatherDataJson, locationJson);
+            GadgetbridgeServiceClass.broadcastWeather(context, weatherSpecsJson);
 
             DEV_LOG && console.log('[Gadgetbridge] Weather data sent to native service for broadcasting', Date.now());
         } catch (error) {
-            console.error('[Gadgetbridge] Failed to broadcast weather:', error, error.stack);
+            // release builds strip console.*, so tell the user once instead of failing silently
+            if (!this.failureReported) {
+                this.failureReported = true;
+                showError(error, { forcedMessage: lc('gadgetbridge_broadcast_failed'), showAsSnack: true });
+            }
         }
     }
 }

--- a/app/services/gadgetbridgePayload.test.ts
+++ b/app/services/gadgetbridgePayload.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import { buildGadgetbridgePayload } from './gadgetbridgePayload';
+import type { WeatherLocation } from '~/services/api';
+import type { CommonWeatherData, Currently, DailyData, Hourly, WeatherData } from '~/services/providers/weather';
+
+const PARIS: WeatherLocation = { name: 'Paris', coord: { lat: 48.86, lon: 2.35 } };
+
+// 2026-01-10 has no moonrise in Paris: suncalc returns `{ set }` only.
+const NO_MOONRISE_DAY = Date.UTC(2026, 0, 10);
+const DAY_MS = 24 * 3600 * 1000;
+
+function commonData(time: number): CommonWeatherData {
+    return { time, aqi: -1, iconId: 800, isDay: true };
+}
+
+function daily(time: number): DailyData {
+    return {
+        ...commonData(time),
+        temperatureMax: 12.4,
+        temperatureMin: 3.6,
+        relativeHumidity: 71,
+        windSpeed: 14.5,
+        windBearing: 220,
+        uvIndex: 1.2,
+        precipProbability: 30
+    };
+}
+
+function hourly(time: number): Hourly {
+    return { ...commonData(time), temperature: 9.7, relativeHumidity: 65, windSpeed: 12, windBearing: 180, uvIndex: 0.5, precipProbability: 10 };
+}
+
+function currently(time: number): Currently {
+    return {
+        ...commonData(time),
+        temperature: 10.9,
+        apparentTemperature: 8.2,
+        dewpoint: 6.1,
+        relativeHumidity: 68,
+        windSpeed: 13.3,
+        windBearing: 200,
+        uvIndex: 0.8,
+        sealevelPressure: 1013.5,
+        cloudCover: 40,
+        description: 'Clear sky'
+    };
+}
+
+function weatherData({ dailyCount = 1, hourlyCount = 0, time = NO_MOONRISE_DAY }: { time?: number; dailyCount?: number; hourlyCount?: number } = {}): WeatherData {
+    return {
+        time,
+        currently: currently(time),
+        daily: { data: Array.from({ length: dailyCount }, (_, index) => daily(time + index * DAY_MS)) },
+        hourly: Array.from({ length: hourlyCount }, (_, index) => hourly(time + index * 3600 * 1000)),
+        minutely: { data: [] },
+        alerts: []
+    };
+}
+
+describe('buildGadgetbridgePayload', () => {
+    it('builds a payload on a day with no moonrise', () => {
+        const payload = buildGadgetbridgePayload(PARIS, weatherData({ dailyCount: 3 }));
+
+        expect(payload).toHaveLength(1);
+        expect(payload[0].location).toBe('Paris');
+        expect(payload[0].moonRise).toBeUndefined();
+        expect(payload[0].moonSet).toBeGreaterThan(0);
+    });
+
+    it('omits sun times when the sun neither rises nor sets', () => {
+        // Svalbard in January: polar night, suncalc returns Invalid Date for sunrise/sunset.
+        const svalbard: WeatherLocation = { name: 'Longyearbyen', coord: { lat: 78.22, lon: 15.65 } };
+        const payload = buildGadgetbridgePayload(svalbard, weatherData());
+
+        expect(payload[0].sunRise).toBeUndefined();
+        expect(payload[0].sunSet).toBeUndefined();
+    });
+
+    it('converts temperatures to Kelvin and timestamps to seconds', () => {
+        const payload = buildGadgetbridgePayload(PARIS, weatherData());
+
+        expect(payload[0].timestamp).toBe(NO_MOONRISE_DAY / 1000);
+        expect(payload[0].currentTemp).toBe(284); // 10.9 + 273.15 truncated
+        expect(payload[0].feelsLikeTemp).toBe(281);
+        expect(payload[0].todayMaxTemp).toBe(285);
+        expect(payload[0].todayMinTemp).toBe(276);
+    });
+
+    it('sends the location coordinates and an unknown current-location flag', () => {
+        const payload = buildGadgetbridgePayload(PARIS, weatherData());
+
+        expect(payload[0].latitude).toBe(48.86);
+        expect(payload[0].longitude).toBe(2.35);
+        expect(payload[0].isCurrentLocation).toBe(-1);
+    });
+
+    it('sends the moon phase in degrees', () => {
+        const payload = buildGadgetbridgePayload(PARIS, weatherData());
+
+        expect(payload[0].moonPhase).toBeGreaterThanOrEqual(0);
+        expect(payload[0].moonPhase).toBeLessThan(360);
+        // 2026-01-10 is a waning moon, past last quarter.
+        expect(payload[0].moonPhase).toBeGreaterThan(180);
+    });
+
+    it('starts forecasts at tomorrow and caps them at 7 days', () => {
+        const payload = buildGadgetbridgePayload(PARIS, weatherData({ dailyCount: 14 }));
+
+        expect(payload[0].forecasts).toHaveLength(7);
+        expect(payload[0].forecasts[0].sunRise).not.toBe(payload[0].sunRise);
+    });
+
+    it('caps hourly forecasts at 48 entries', () => {
+        const payload = buildGadgetbridgePayload(PARIS, weatherData({ hourlyCount: 72 }));
+
+        expect(payload[0].hourly).toHaveLength(48);
+        expect(payload[0].hourly[0].temp).toBe(282);
+    });
+
+    it('omits air quality when there is no aqi', () => {
+        const payload = buildGadgetbridgePayload(PARIS, weatherData());
+
+        expect(payload[0].airQuality).toBeUndefined();
+    });
+
+    it('includes air quality and pollutants when available', () => {
+        const data = weatherData();
+        data.currently.aqi = 42;
+        data.currently.pollutants = { pm2_5: { unit: 'µg/m³', value: 12.3 }, o3: { unit: 'µg/m³', value: 60 } };
+        const payload = buildGadgetbridgePayload(PARIS, data);
+
+        expect(payload[0].airQuality).toEqual({ aqi: 42, pm25: 12.3, o3: 60 });
+    });
+});

--- a/app/services/gadgetbridgePayload.ts
+++ b/app/services/gadgetbridgePayload.ts
@@ -1,0 +1,261 @@
+import { getMoonTimes, getTimes } from 'suncalc';
+import { getMoonPhaseDegrees } from '~/helpers/moon';
+import type { WeatherLocation } from '~/services/api';
+import type { CommonWeatherData, DailyData, Hourly, WeatherData } from '~/services/providers/weather';
+
+/**
+ * Gadgetbridge weather payload builders.
+ *
+ * The shape follows Gadgetbridge's `WeatherSpec` (see
+ * https://gadgetbridge.org/internals/development/weather-support/): temperatures in Kelvin,
+ * timestamps in seconds, wind speed in km/h, condition codes are OpenWeatherMap codes.
+ * The native side only gzips the JSON produced here and broadcasts it.
+ */
+
+const MAX_DAILY_FORECASTS = 8;
+const MAX_HOURLY_FORECASTS = 48;
+
+export interface GadgetbridgeAirQuality {
+    aqi: number;
+    co?: number;
+    no2?: number;
+    o3?: number;
+    pm10?: number;
+    pm25?: number;
+    so2?: number;
+}
+
+export interface GadgetbridgeDaily {
+    conditionCode: number;
+    maxTemp: number;
+    minTemp: number;
+    humidity: number;
+    windSpeed: number;
+    windDirection: number;
+    uvIndex: number;
+    precipProbability: number;
+    sunRise?: number;
+    sunSet?: number;
+    moonRise?: number;
+    moonSet?: number;
+    moonPhase?: number;
+    airQuality?: GadgetbridgeAirQuality;
+}
+
+export interface GadgetbridgeHourly {
+    timestamp: number;
+    temp: number;
+    conditionCode: number;
+    humidity: number;
+    windSpeed: number;
+    windDirection: number;
+    uvIndex: number;
+    precipProbability: number;
+}
+
+export interface GadgetbridgeWeatherSpec {
+    timestamp: number;
+    location: string;
+    latitude: number;
+    longitude: number;
+    /** 0 false, 1 true, -1 unknown. */
+    isCurrentLocation: number;
+    currentTemp?: number;
+    currentConditionCode?: number;
+    currentCondition?: string;
+    currentHumidity?: number;
+    windSpeed?: number;
+    windDirection?: number;
+    uvIndex?: number;
+    feelsLikeTemp?: number;
+    dewPoint?: number;
+    pressure?: number;
+    cloudCover?: number;
+    todayMaxTemp?: number;
+    todayMinTemp?: number;
+    precipProbability?: number;
+    sunRise?: number;
+    sunSet?: number;
+    moonRise?: number;
+    moonSet?: number;
+    moonPhase?: number;
+    airQuality?: GadgetbridgeAirQuality;
+    forecasts?: GadgetbridgeDaily[];
+    hourly?: GadgetbridgeHourly[];
+}
+
+interface SunMoonTimes {
+    sunRise?: number;
+    sunSet?: number;
+    moonRise?: number;
+    moonSet?: number;
+    moonPhase: number;
+}
+
+function toInt(value: number, fallback = 0) {
+    return Number.isFinite(value) ? Math.trunc(value) : fallback;
+}
+
+function toSeconds(milliseconds: number) {
+    return Math.trunc(milliseconds / 1000);
+}
+
+function kelvinFromCelsius(celsius: number, fallback = 0) {
+    return Math.trunc((Number.isFinite(celsius) ? celsius : fallback) + 273.15);
+}
+
+/**
+ * suncalc omits `rise`/`set` when the event does not happen that day (the moon skips a rise about
+ * once per lunar month, and there is no sunrise at all during a polar night, where `getTimes`
+ * returns an `Invalid Date`). Every value is therefore optional: an omitted field lets Gadgetbridge
+ * fall back to its own default instead of receiving a bogus timestamp — and reading `.valueOf()` on
+ * a missing one used to throw and kill the whole broadcast.
+ */
+function toEventSeconds(date?: Date) {
+    const time = date?.valueOf();
+    return time !== undefined && Number.isFinite(time) ? toSeconds(time) : undefined;
+}
+
+function computeSunMoonTimes(day: DailyData, location: WeatherLocation): SunMoonTimes {
+    const date = new Date(day.time);
+    const times = getTimes(date, location.coord.lat, location.coord.lon);
+    const moonTimes = getMoonTimes(date, location.coord.lat, location.coord.lon, true);
+    return {
+        sunRise: toEventSeconds(times.sunriseEnd),
+        sunSet: toEventSeconds(times.sunsetStart),
+        moonRise: toEventSeconds(moonTimes.rise),
+        moonSet: toEventSeconds(moonTimes.set),
+        moonPhase: getMoonPhaseDegrees(date)
+    };
+}
+
+function assignSunMoonTimes(target: GadgetbridgeDaily | GadgetbridgeWeatherSpec, sunMoon: SunMoonTimes) {
+    target.moonPhase = sunMoon.moonPhase;
+    if (sunMoon.sunRise !== undefined) {
+        target.sunRise = sunMoon.sunRise;
+    }
+    if (sunMoon.sunSet !== undefined) {
+        target.sunSet = sunMoon.sunSet;
+    }
+    if (sunMoon.moonRise !== undefined) {
+        target.moonRise = sunMoon.moonRise;
+    }
+    if (sunMoon.moonSet !== undefined) {
+        target.moonSet = sunMoon.moonSet;
+    }
+}
+
+function buildAirQuality(data: CommonWeatherData): GadgetbridgeAirQuality | undefined {
+    const aqi = toInt(data.aqi, -1);
+    if (aqi <= 0) {
+        return undefined;
+    }
+    const pollutants = data.pollutants;
+    const airQuality: GadgetbridgeAirQuality = { aqi };
+    if (pollutants) {
+        if (pollutants.co) {
+            airQuality.co = pollutants.co.value;
+        }
+        if (pollutants.no2) {
+            airQuality.no2 = pollutants.no2.value;
+        }
+        if (pollutants.o3) {
+            airQuality.o3 = pollutants.o3.value;
+        }
+        if (pollutants.pm10) {
+            airQuality.pm10 = pollutants.pm10.value;
+        }
+        if (pollutants.pm2_5) {
+            airQuality.pm25 = pollutants.pm2_5.value;
+        }
+        if (pollutants.so2) {
+            airQuality.so2 = pollutants.so2.value;
+        }
+    }
+    return airQuality;
+}
+
+function buildDailyForecast(day: DailyData, location: WeatherLocation): GadgetbridgeDaily {
+    const forecast: GadgetbridgeDaily = {
+        conditionCode: toInt(day.iconId, 3200),
+        maxTemp: kelvinFromCelsius(day.temperatureMax),
+        minTemp: kelvinFromCelsius(day.temperatureMin),
+        humidity: toInt(day.relativeHumidity),
+        windSpeed: day.windSpeed ?? 0,
+        windDirection: toInt(day.windBearing),
+        uvIndex: day.uvIndex ?? 0,
+        precipProbability: toInt(day.precipProbability)
+    };
+    assignSunMoonTimes(forecast, computeSunMoonTimes(day, location));
+    const airQuality = buildAirQuality(day);
+    if (airQuality) {
+        forecast.airQuality = airQuality;
+    }
+    return forecast;
+}
+
+function buildHourlyForecast(hour: Hourly): GadgetbridgeHourly {
+    return {
+        timestamp: toSeconds(hour.time),
+        temp: kelvinFromCelsius(hour.temperature),
+        conditionCode: toInt(hour.iconId, 3200),
+        humidity: toInt(hour.relativeHumidity),
+        windSpeed: hour.windSpeed ?? 0,
+        windDirection: toInt(hour.windBearing),
+        uvIndex: hour.uvIndex ?? 0,
+        precipProbability: toInt(hour.precipProbability)
+    };
+}
+
+/**
+ * Build the array of `WeatherSpec` objects Gadgetbridge expects in its `WeatherGz` extra.
+ */
+export function buildGadgetbridgePayload(location: WeatherLocation, weatherData: WeatherData): GadgetbridgeWeatherSpec[] {
+    const spec: GadgetbridgeWeatherSpec = {
+        timestamp: toSeconds(weatherData.time),
+        location: location.name ?? '',
+        latitude: location.coord.lat,
+        longitude: location.coord.lon,
+        // a GPS fix is geocoded and stored like any manually added city, so we cannot tell them apart
+        isCurrentLocation: -1
+    };
+
+    const currently = weatherData.currently;
+    if (currently) {
+        spec.currentTemp = kelvinFromCelsius(currently.temperature);
+        spec.currentConditionCode = toInt(currently.iconId, 3200);
+        spec.currentCondition = currently.description ?? '';
+        spec.currentHumidity = toInt(currently.relativeHumidity);
+        spec.windSpeed = currently.windSpeed ?? 0;
+        spec.windDirection = toInt(currently.windBearing);
+        spec.uvIndex = currently.uvIndex ?? 0;
+        spec.feelsLikeTemp = kelvinFromCelsius(currently.apparentTemperature);
+        spec.dewPoint = kelvinFromCelsius(currently.dewpoint);
+        spec.pressure = currently.sealevelPressure ?? 0;
+        spec.cloudCover = toInt(currently.cloudCover);
+        const airQuality = buildAirQuality(currently);
+        if (airQuality) {
+            spec.airQuality = airQuality;
+        }
+    }
+
+    const daily = weatherData.daily?.data;
+    if (daily?.length) {
+        const today = daily[0];
+        spec.todayMaxTemp = kelvinFromCelsius(today.temperatureMax);
+        spec.todayMinTemp = kelvinFromCelsius(today.temperatureMin);
+        spec.precipProbability = toInt(today.precipProbability);
+        assignSunMoonTimes(spec, computeSunMoonTimes(today, location));
+
+        if (daily.length > 1) {
+            spec.forecasts = daily.slice(1, MAX_DAILY_FORECASTS).map((day) => buildDailyForecast(day, location));
+        }
+    }
+
+    const hourly = weatherData.hourly;
+    if (hourly?.length) {
+        spec.hourly = hourly.slice(0, MAX_HOURLY_FORECASTS).map(buildHourlyForecast);
+    }
+
+    return [spec];
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
         "prepare.android.benchmark": "cross-var ns prepare android --release --clean --key-store-path $KEYSTORE_PATH --key-store-password $KEYSTORE_PASSWORD --key-store-alias $KEYSTORE_ALIAS --key-store-alias-password $KEYSTORE_ALIAS_PASSWORD --env.adhoc",
         "build.android.baselineprofile": "npm run prepare.android.benchmark ; ./$APP_BUILD_PATH/android/gradlew -p ./$APP_BUILD_PATH/android :benchmark:pixel2Api31BenchmarkAndroidTest -Pandroid.testoptions.manageddevices.emulator.gpu=\"swiftshader_indirect\" -Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.enabledRules=BaselineProfile -Dorg.gradle.workers.max=4 --stacktrace; mv -f ./$APP_BUILD_PATH/android/benchmark/build/outputs/managed_device_android_test_additional_output/pixel2Api31/BaselineProfileGenerator_startup-baseline-prof.txt $APP_RESOURCES/Android/src/main/baseline-prof.txt",
         "svelte-check": "svelte-check --compiler-warnings 'a11y-no-onchange:ignore,a11y-label-has-associated-control:ignore,a11y-autofocus:ignore,illegal-attribute-character:ignore'",
+        "test": "vitest run",
+        "test:watch": "vitest",
         "sync": "node ./tools/sync.mjs",
         "update": "node ./tools/update.mjs",
         "setup": "npm run submodules",
@@ -108,7 +110,8 @@
         "mini-css-extract-plugin": "^2.10.2",
         "minimizer-webpack-plugin": "^5.6.1",
         "svelte-loader": "3.2.4",
-        "swc-loader": "^0.2.7"
+        "swc-loader": "^0.2.7",
+        "vitest": "^4.1.10"
     },
     "commitlint": {
         "extends": [

--- a/typings/android.d.ts
+++ b/typings/android.d.ts
@@ -20,7 +20,7 @@ declare namespace com {
             }
             export namespace gadgetbridge {
                 export class GadgetbridgeService {
-                    static broadcastWeather(context: globalAndroid.content.Context, weatherDataJson: string, locationJson: string);
+                    static broadcastWeather(context: globalAndroid.content.Context, weatherSpecsJson: string);
                 }
             }
             export namespace ImageUtils {

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,0 +1,15 @@
+import { resolve } from 'path';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    resolve: {
+        alias: {
+            '~': resolve(__dirname, 'app'),
+            '@shared': resolve(__dirname, 'tools/app')
+        }
+    },
+    test: {
+        environment: 'node',
+        include: ['app/**/*.test.ts']
+    }
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3256,6 +3256,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@oxc-project/types@npm:=0.143.0":
+  version: 0.143.0
+  resolution: "@oxc-project/types@npm:0.143.0"
+  checksum: 10/27a70f58e15ea5619b94f1be01a0e3d8cdc41442826f3d08cf6eb55e4c24d3d753cef2a68ae9d298eb55b5f1405145af6b1eacf8cbd4834151b9e3e1206f3401
+  languageName: node
+  linkType: hard
+
 "@parcel/watcher-android-arm64@npm:2.5.6":
   version: 2.5.6
   resolution: "@parcel/watcher-android-arm64@npm:2.5.6"
@@ -3478,6 +3485,111 @@ __metadata:
   bin:
     browsers: lib/cjs/main-cli.js
   checksum: 10/c0c74d8a5ab5b9f6a829f488002f63247d3c4dabfd57cab9944e1bde8ce13e568f86633cb38fdf89d234826b110b2bb570da9278c598fa409816234cdebf5166
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-android-arm64@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-android-arm64@npm:1.2.3"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-darwin-arm64@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-darwin-arm64@npm:1.2.3"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-darwin-x64@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-darwin-x64@npm:1.2.3"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-freebsd-x64@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-freebsd-x64@npm:1.2.3"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm-gnueabihf@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.2.3"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm64-gnu@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.2.3"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm64-musl@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-linux-arm64-musl@npm:1.2.3"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-ppc64-gnu@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-linux-ppc64-gnu@npm:1.2.3"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-s390x-gnu@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-linux-s390x-gnu@npm:1.2.3"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-x64-gnu@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-linux-x64-gnu@npm:1.2.3"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-x64-musl@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-linux-x64-musl@npm:1.2.3"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-openharmony-arm64@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-openharmony-arm64@npm:1.2.3"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-win32-arm64-msvc@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.2.3"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-win32-x64-msvc@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-win32-x64-msvc@npm:1.2.3"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/pluginutils@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "@rolldown/pluginutils@npm:1.0.1"
+  checksum: 10/4e95cf9ce23d75e5aa03ea0249cd86f7d1e21f83fbf6f8520e4edd8a251ba1b82c4ba9bc13cd24b6c4661daec6225b06e6d35c64c604e731b230b2a49af47d05
   languageName: node
   linkType: hard
 
@@ -4009,6 +4121,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@standard-schema/spec@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@standard-schema/spec@npm:1.1.0"
+  checksum: 10/a209615c9e8b2ea535d7db0a5f6aa0f962fd4ab73ee86a46c100fb78116964af1f55a27c1794d4801e534a196794223daa25ff5135021e03c7828aa3d95e1763
+  languageName: node
+  linkType: hard
+
 "@stylistic/eslint-plugin-plus@npm:4.4.1":
   version: 4.4.1
   resolution: "@stylistic/eslint-plugin-plus@npm:4.4.1"
@@ -4278,6 +4397,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/chai@npm:^5.2.2":
+  version: 5.2.3
+  resolution: "@types/chai@npm:5.2.3"
+  dependencies:
+    "@types/deep-eql": "npm:*"
+    assertion-error: "npm:^2.0.1"
+  checksum: 10/e79947307dc235953622e65f83d2683835212357ca261389116ab90bed369ac862ba28b146b4fed08b503ae1e1a12cb93ce783f24bb8d562950469f4320e1c7c
+  languageName: node
+  linkType: hard
+
 "@types/connect-history-api-fallback@npm:^1.5.4":
   version: 1.5.4
   resolution: "@types/connect-history-api-fallback@npm:1.5.4"
@@ -4294,6 +4423,13 @@ __metadata:
   dependencies:
     "@types/node": "npm:*"
   checksum: 10/7eb1bc5342a9604facd57598a6c62621e244822442976c443efb84ff745246b10d06e8b309b6e80130026a396f19bf6793b7cecd7380169f369dac3bfc46fb99
+  languageName: node
+  linkType: hard
+
+"@types/deep-eql@npm:*":
+  version: 4.0.2
+  resolution: "@types/deep-eql@npm:4.0.2"
+  checksum: 10/249a27b0bb22f6aa28461db56afa21ec044fa0e303221a62dff81831b20c8530502175f1a49060f7099e7be06181078548ac47c668de79ff9880241968d43d0c
   languageName: node
   linkType: hard
 
@@ -4905,6 +5041,88 @@ __metadata:
   version: 1.3.1
   resolution: "@ungap/structured-clone@npm:1.3.1"
   checksum: 10/64df206f50aef71c176f9059c1b29e1694821419c6728c446ecf39c80a811eeef156668bf51421b676494a12fd0129ccf09a44f0c641f13c27f50d5f0db6de4e
+  languageName: node
+  linkType: hard
+
+"@vitest/expect@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/expect@npm:4.1.10"
+  dependencies:
+    "@standard-schema/spec": "npm:^1.1.0"
+    "@types/chai": "npm:^5.2.2"
+    "@vitest/spy": "npm:4.1.10"
+    "@vitest/utils": "npm:4.1.10"
+    chai: "npm:^6.2.2"
+    tinyrainbow: "npm:^3.1.0"
+  checksum: 10/487fcad404a68968a54ae5fb9d099f12170cd793420a04b34a5606516317090c50a8303ab687c70166ee181864e3e138941d4a96d0405434dcd37696b3105350
+  languageName: node
+  linkType: hard
+
+"@vitest/mocker@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/mocker@npm:4.1.10"
+  dependencies:
+    "@vitest/spy": "npm:4.1.10"
+    estree-walker: "npm:^3.0.3"
+    magic-string: "npm:^0.30.21"
+  peerDependencies:
+    msw: ^2.4.9
+    vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+  peerDependenciesMeta:
+    msw:
+      optional: true
+    vite:
+      optional: true
+  checksum: 10/ae9645d1bcdad3ab7de7182feb4f1c9148a5ff97cef19581eec9257112aace94889eee9a1ad12e40ce59453ac05f52453b5fdb49ff76a31af8ccdbaaa4471ef3
+  languageName: node
+  linkType: hard
+
+"@vitest/pretty-format@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/pretty-format@npm:4.1.10"
+  dependencies:
+    tinyrainbow: "npm:^3.1.0"
+  checksum: 10/e4f6907143ab0e40dda29d70b17027586c92921d622091321f10512e660b3995dcee7aa56e17b750b72560f295e25f96035372348415f18ebfd39b66a55b4704
+  languageName: node
+  linkType: hard
+
+"@vitest/runner@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/runner@npm:4.1.10"
+  dependencies:
+    "@vitest/utils": "npm:4.1.10"
+    pathe: "npm:^2.0.3"
+  checksum: 10/2c962cb13af0880990036808a35679b7ac6657c8f542490234c2faa6ffd2ab080ac6bf21b487c64d84aa635cfb37b49eb679098c2003a100dfc6c4d5e87bf055
+  languageName: node
+  linkType: hard
+
+"@vitest/snapshot@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/snapshot@npm:4.1.10"
+  dependencies:
+    "@vitest/pretty-format": "npm:4.1.10"
+    "@vitest/utils": "npm:4.1.10"
+    magic-string: "npm:^0.30.21"
+    pathe: "npm:^2.0.3"
+  checksum: 10/7940d83ffd2fbebf9a04ea31e196b7e8bf981093ec739950959fe8dd29caa33c80823780fb4b1063d9459c44a0a8d8b2748c00dfb6941becd7404e6d687eea01
+  languageName: node
+  linkType: hard
+
+"@vitest/spy@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/spy@npm:4.1.10"
+  checksum: 10/7c1b79a95474338e0659f0f2e43be4df1ef7939ff5b37b044954e0287582947803bd417508f44a7f244809672309d9b3dd67660b704ec3fe7f323cc958ae47a3
+  languageName: node
+  linkType: hard
+
+"@vitest/utils@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/utils@npm:4.1.10"
+  dependencies:
+    "@vitest/pretty-format": "npm:4.1.10"
+    convert-source-map: "npm:^2.0.0"
+    tinyrainbow: "npm:^3.1.0"
+  checksum: 10/95484aad55c7b00bbcd4963e27cbb86fe207620a6093973d68da9d0a06bad37c388d84c9ab43d5f35d88e46c8f376a5592d9c54c025c958361160f4802bb25ee
   languageName: node
   linkType: hard
 
@@ -5529,6 +5747,13 @@ __metadata:
   version: 1.1.1
   resolution: "array-flatten@npm:1.1.1"
   checksum: 10/e13c9d247241be82f8b4ec71d035ed7204baa82fae820d4db6948d30d3c4a9f2b3905eb2eec2b937d4aa3565200bd3a1c500480114cff649fa748747d2a50feb
+  languageName: node
+  linkType: hard
+
+"assertion-error@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "assertion-error@npm:2.0.1"
+  checksum: 10/a0789dd882211b87116e81e2648ccb7f60340b34f19877dd020b39ebb4714e475eb943e14ba3e22201c221ef6645b7bfe10297e76b6ac95b48a9898c1211ce66
   languageName: node
   linkType: hard
 
@@ -6917,6 +7142,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chai@npm:^6.2.2":
+  version: 6.2.2
+  resolution: "chai@npm:6.2.2"
+  checksum: 10/13cda42cc40aa46da04a41cf7e5c61df6b6ae0b4e8a8c8b40e04d6947e4d7951377ea8c14f9fa7fe5aaa9e8bd9ba414f11288dc958d4cee6f5221b9436f2778f
+  languageName: node
+  linkType: hard
+
 "chalk@npm:^1.1.3":
   version: 1.1.3
   resolution: "chalk@npm:1.1.3"
@@ -8286,6 +8518,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-module-lexer@npm:^2.0.0":
+  version: 2.3.1
+  resolution: "es-module-lexer@npm:2.3.1"
+  checksum: 10/15bd9f6d70ec7f046a308b7fbeb56a1fd4bde09e6a46df0015caee58bd5888fc114029754e922ca68577b761890ac95cc450683424209464530cfe54f69b8566
+  languageName: node
+  linkType: hard
+
 "es-module-lexer@npm:^2.1.0":
   version: 2.1.0
   resolution: "es-module-lexer@npm:2.1.0"
@@ -8952,6 +9191,13 @@ __metadata:
   version: 0.1.2
   resolution: "exit@npm:0.1.2"
   checksum: 10/387555050c5b3c10e7a9e8df5f43194e95d7737c74532c409910e585d5554eaff34960c166643f5e23d042196529daad059c292dcf1fb61b8ca878d3677f4b87
+  languageName: node
+  linkType: hard
+
+"expect-type@npm:^1.3.0":
+  version: 1.4.0
+  resolution: "expect-type@npm:1.4.0"
+  checksum: 10/bad91f4b7eb807248695ee840a935d12818fe531ad523bc7ac7dcc540a4d86dc566a3ef829f4da6e8b5a458ac84092771739865114c91e7e8a9317302f401f09
   languageName: node
   linkType: hard
 
@@ -10690,6 +10936,126 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lightningcss-android-arm64@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-android-arm64@npm:1.33.0"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lightningcss-darwin-arm64@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-darwin-arm64@npm:1.33.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lightningcss-darwin-x64@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-darwin-x64@npm:1.33.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lightningcss-freebsd-x64@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-freebsd-x64@npm:1.33.0"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-arm-gnueabihf@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-linux-arm-gnueabihf@npm:1.33.0"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-arm64-gnu@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-linux-arm64-gnu@npm:1.33.0"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-arm64-musl@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-linux-arm64-musl@npm:1.33.0"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-x64-gnu@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-linux-x64-gnu@npm:1.33.0"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-x64-musl@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-linux-x64-musl@npm:1.33.0"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"lightningcss-win32-arm64-msvc@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-win32-arm64-msvc@npm:1.33.0"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lightningcss-win32-x64-msvc@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-win32-x64-msvc@npm:1.33.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lightningcss@npm:^1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss@npm:1.33.0"
+  dependencies:
+    detect-libc: "npm:^2.0.3"
+    lightningcss-android-arm64: "npm:1.33.0"
+    lightningcss-darwin-arm64: "npm:1.33.0"
+    lightningcss-darwin-x64: "npm:1.33.0"
+    lightningcss-freebsd-x64: "npm:1.33.0"
+    lightningcss-linux-arm-gnueabihf: "npm:1.33.0"
+    lightningcss-linux-arm64-gnu: "npm:1.33.0"
+    lightningcss-linux-arm64-musl: "npm:1.33.0"
+    lightningcss-linux-x64-gnu: "npm:1.33.0"
+    lightningcss-linux-x64-musl: "npm:1.33.0"
+    lightningcss-win32-arm64-msvc: "npm:1.33.0"
+    lightningcss-win32-x64-msvc: "npm:1.33.0"
+  dependenciesMeta:
+    lightningcss-android-arm64:
+      optional: true
+    lightningcss-darwin-arm64:
+      optional: true
+    lightningcss-darwin-x64:
+      optional: true
+    lightningcss-freebsd-x64:
+      optional: true
+    lightningcss-linux-arm-gnueabihf:
+      optional: true
+    lightningcss-linux-arm64-gnu:
+      optional: true
+    lightningcss-linux-arm64-musl:
+      optional: true
+    lightningcss-linux-x64-gnu:
+      optional: true
+    lightningcss-linux-x64-musl:
+      optional: true
+    lightningcss-win32-arm64-msvc:
+      optional: true
+    lightningcss-win32-x64-msvc:
+      optional: true
+  checksum: 10/9b3b5db404af352fe5861926b9909281d29bede175539035c1a01e1ad4dcee8bb6f871e8e3d01a67a85e9e1cd18a63e52871a48cf62feab4d1aa868d4f2c3c2e
+  languageName: node
+  linkType: hard
+
 "lilconfig@npm:^2.0.5":
   version: 2.1.0
   resolution: "lilconfig@npm:2.1.0"
@@ -11470,6 +11836,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nanoid@npm:^3.3.17":
+  version: 3.3.18
+  resolution: "nanoid@npm:3.3.18"
+  bin:
+    nanoid: bin/nanoid.cjs
+  checksum: 10/1b3b4fdac831b92b56d1dbe8b1e63a372432faf86ea383134e3b53141ef8108a60b7f84343b5cefecac9550bb74edf8164da93ea07d1c4f757039bc75d8a5d9e
+  languageName: node
+  linkType: hard
+
 "nativescript-hook@npm:^0.2.5":
   version: 0.2.5
   resolution: "nativescript-hook@npm:0.2.5"
@@ -11717,6 +12092,13 @@ __metadata:
   version: 1.1.2
   resolution: "obuf@npm:1.1.2"
   checksum: 10/53ff4ab3a13cc33ba6c856cf281f2965c0aec9720967af450e8fd06cfd50aceeefc791986a16bcefa14e7898b3ca9acdfcf15b9d9a1b9c7e1366581a8ad6e65e
+  languageName: node
+  linkType: hard
+
+"obug@npm:^2.1.1":
+  version: 2.1.4
+  resolution: "obug@npm:2.1.4"
+  checksum: 10/05e3ac83f60ef18edb935d67703bada2cbc0feb1a1cef575240b1e48e6e877df95b74048e69bbe549759df18c57ad1808e1e60a9fc4f785525c8549bf7fe81db
   languageName: node
   linkType: hard
 
@@ -12125,6 +12507,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pathe@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "pathe@npm:2.0.3"
+  checksum: 10/01e9a69928f39087d96e1751ce7d6d50da8c39abf9a12e0ac2389c42c83bc76f78c45a475bd9026a02e6a6f79be63acc75667df855862fe567d99a00a540d23d
+  languageName: node
+  linkType: hard
+
 "pbf@npm:4.0.1":
   version: 4.0.1
   resolution: "pbf@npm:4.0.1"
@@ -12206,6 +12595,13 @@ __metadata:
   version: 4.0.4
   resolution: "picomatch@npm:4.0.4"
   checksum: 10/f6ef80a3590827ce20378ae110ac78209cc4f74d39236370f1780f957b7ee41c12acde0e4651b90f39983506fd2f5e449994716f516db2e9752924aff8de93ce
+  languageName: node
+  linkType: hard
+
+"picomatch@npm:^4.0.5":
+  version: 4.0.5
+  resolution: "picomatch@npm:4.0.5"
+  checksum: 10/8bad770af9dcdb7f94ad1a893adcbe08a97d75a18872f8fed37161d3124217471c402b3929f051532f795f4ff2e53dcebb1644df4c1a5f3a9c476fef3b9f8c51
   languageName: node
   linkType: hard
 
@@ -12857,6 +13253,17 @@ __metadata:
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
   checksum: 10/d02ad19eb1e0fa53a1229ee6d53807eb88f903f2b9a8cac66993367f3ac7dd3b97238c783a54ccbf4145f82f6ca9a5cbd58f089846285d759c8a3259fbea8318
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.5.25":
+  version: 8.5.26
+  resolution: "postcss@npm:8.5.26"
+  dependencies:
+    nanoid: "npm:^3.3.17"
+    picocolors: "npm:^1.1.1"
+    source-map-js: "npm:^1.2.1"
+  checksum: 10/842a624f822f77cb37264cc24f0cf97c0a69dd8d6f7b4a6d76b5a8dc95355899dd044f33a2d4e890da858293de570fce18dff453f3b629ff14cac67a3591895a
   languageName: node
   linkType: hard
 
@@ -13588,6 +13995,61 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rolldown@npm:~1.2.1":
+  version: 1.2.3
+  resolution: "rolldown@npm:1.2.3"
+  dependencies:
+    "@oxc-project/types": "npm:=0.143.0"
+    "@rolldown/binding-android-arm64": "npm:1.2.3"
+    "@rolldown/binding-darwin-arm64": "npm:1.2.3"
+    "@rolldown/binding-darwin-x64": "npm:1.2.3"
+    "@rolldown/binding-freebsd-x64": "npm:1.2.3"
+    "@rolldown/binding-linux-arm-gnueabihf": "npm:1.2.3"
+    "@rolldown/binding-linux-arm64-gnu": "npm:1.2.3"
+    "@rolldown/binding-linux-arm64-musl": "npm:1.2.3"
+    "@rolldown/binding-linux-ppc64-gnu": "npm:1.2.3"
+    "@rolldown/binding-linux-s390x-gnu": "npm:1.2.3"
+    "@rolldown/binding-linux-x64-gnu": "npm:1.2.3"
+    "@rolldown/binding-linux-x64-musl": "npm:1.2.3"
+    "@rolldown/binding-openharmony-arm64": "npm:1.2.3"
+    "@rolldown/binding-win32-arm64-msvc": "npm:1.2.3"
+    "@rolldown/binding-win32-x64-msvc": "npm:1.2.3"
+    "@rolldown/pluginutils": "npm:^1.0.0"
+  dependenciesMeta:
+    "@rolldown/binding-android-arm64":
+      optional: true
+    "@rolldown/binding-darwin-arm64":
+      optional: true
+    "@rolldown/binding-darwin-x64":
+      optional: true
+    "@rolldown/binding-freebsd-x64":
+      optional: true
+    "@rolldown/binding-linux-arm-gnueabihf":
+      optional: true
+    "@rolldown/binding-linux-arm64-gnu":
+      optional: true
+    "@rolldown/binding-linux-arm64-musl":
+      optional: true
+    "@rolldown/binding-linux-ppc64-gnu":
+      optional: true
+    "@rolldown/binding-linux-s390x-gnu":
+      optional: true
+    "@rolldown/binding-linux-x64-gnu":
+      optional: true
+    "@rolldown/binding-linux-x64-musl":
+      optional: true
+    "@rolldown/binding-openharmony-arm64":
+      optional: true
+    "@rolldown/binding-win32-arm64-msvc":
+      optional: true
+    "@rolldown/binding-win32-x64-msvc":
+      optional: true
+  bin:
+    rolldown: ./bin/cli.mjs
+  checksum: 10/553fae06b40d5df3679685807971525b5b5b5fc4e0b5bc661d4cc4214aa6f316b460c6cb296d0352db75287f1fc38cfad1505e54920714e94ac837d1f6e8eceb
+  languageName: node
+  linkType: hard
+
 "rollup@npm:^4.43.0":
   version: 4.61.1
   resolution: "rollup@npm:4.61.1"
@@ -13751,6 +14213,7 @@ __metadata:
     suncalc: "npm:1.9.0"
     svelte-loader: "npm:3.2.4"
     swc-loader: "npm:^0.2.7"
+    vitest: "npm:^4.1.10"
     weather-icons: "npm:1.3.2"
   languageName: unknown
   linkType: soft
@@ -14147,6 +14610,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"siginfo@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "siginfo@npm:2.0.0"
+  checksum: 10/e93ff66c6531a079af8fb217240df01f980155b5dc408d2d7bebc398dd284e383eb318153bf8acd4db3c4fe799aa5b9a641e38b0ba3b1975700b1c89547ea4e7
+  languageName: node
+  linkType: hard
+
 "signal-exit@npm:^3.0.0, signal-exit@npm:^3.0.3":
   version: 3.0.7
   resolution: "signal-exit@npm:3.0.7"
@@ -14372,6 +14842,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stackback@npm:0.0.2":
+  version: 0.0.2
+  resolution: "stackback@npm:0.0.2"
+  checksum: 10/2d4dc4e64e2db796de4a3c856d5943daccdfa3dd092e452a1ce059c81e9a9c29e0b9badba91b43ef0d5ff5c04ee62feb3bcc559a804e16faf447bac2d883aa99
+  languageName: node
+  linkType: hard
+
 "stackframe@npm:^1.3.4":
   version: 1.3.4
   resolution: "stackframe@npm:1.3.4"
@@ -14410,6 +14887,13 @@ __metadata:
   version: 2.0.2
   resolution: "statuses@npm:2.0.2"
   checksum: 10/6927feb50c2a75b2a4caab2c565491f7a93ad3d8dbad7b1398d52359e9243a20e2ebe35e33726dee945125ef7a515e9097d8a1b910ba2bbd818265a2f6c39879
+  languageName: node
+  linkType: hard
+
+"std-env@npm:^4.0.0-rc.1":
+  version: 4.2.0
+  resolution: "std-env@npm:4.2.0"
+  checksum: 10/d30c3ae49c5568b4e61dca628eaafe12944dbcfe76980e5b1b1499b48e23f85f1ee01fe2306eeef5964a80b763948bbf2ba40490bc53709f45cf989071c9e4e7
   languageName: node
   linkType: hard
 
@@ -15073,7 +15557,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.15":
+"tinybench@npm:^2.9.0":
+  version: 2.9.0
+  resolution: "tinybench@npm:2.9.0"
+  checksum: 10/cfa1e1418e91289219501703c4693c70708c91ffb7f040fd318d24aef419fb5a43e0c0160df9471499191968b2451d8da7f8087b08c3133c251c40d24aced06c
+  languageName: node
+  linkType: hard
+
+"tinyexec@npm:^1.0.2":
+  version: 1.3.0
+  resolution: "tinyexec@npm:1.3.0"
+  checksum: 10/749a8c5aac2ffe3f04220b8966f414636c6c324d4ae88895dfffb2319db61cf1c01c5d7e8f0fb8ab747389ea0be1f0f80d850a9cce88a9d96cc5ebcb345db018
+  languageName: node
+  linkType: hard
+
+"tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.15, tinyglobby@npm:^0.2.17":
   version: 0.2.17
   resolution: "tinyglobby@npm:0.2.17"
   dependencies:
@@ -15087,6 +15585,13 @@ __metadata:
   version: 3.0.0
   resolution: "tinyqueue@npm:3.0.0"
   checksum: 10/44195ae628e98f4de49acefac1fafa63a7f2b5d8a5c23ace6f49917109db3435db8ec9854f87c0d50f8a8c6a73f1526f3941921618a071e4ee1d246afacf69bb
+  languageName: node
+  linkType: hard
+
+"tinyrainbow@npm:^3.1.0":
+  version: 3.1.1
+  resolution: "tinyrainbow@npm:3.1.1"
+  checksum: 10/6aa4aadf89cc8ecf8c227ef189616911292c4f0d2d5708b669b00375c5a8b43058115685f043034ffb11a8744c24650a30493525ff62134b436d94c84fa33ed5
   languageName: node
   linkType: hard
 
@@ -15698,6 +16203,63 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vite@npm:^6.0.0 || ^7.0.0 || ^8.0.0":
+  version: 8.2.1
+  resolution: "vite@npm:8.2.1"
+  dependencies:
+    fsevents: "npm:~2.3.3"
+    lightningcss: "npm:^1.33.0"
+    picomatch: "npm:^4.0.5"
+    postcss: "npm:^8.5.25"
+    rolldown: "npm:~1.2.1"
+    tinyglobby: "npm:^0.2.17"
+  peerDependencies:
+    "@types/node": ^20.19.0 || >=22.12.0
+    "@vitejs/devtools": ^0.4.0
+    esbuild: ^0.27.0 || ^0.28.0
+    jiti: ">=1.21.0"
+    less: ^4.0.0
+    sass: ^1.70.0
+    sass-embedded: ^1.70.0
+    stylus: ">=0.54.8"
+    sugarss: ^5.0.0
+    terser: ^5.16.0
+    tsx: ^4.8.1
+    yaml: ^2.4.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    "@vitejs/devtools":
+      optional: true
+    esbuild:
+      optional: true
+    jiti:
+      optional: true
+    less:
+      optional: true
+    sass:
+      optional: true
+    sass-embedded:
+      optional: true
+    stylus:
+      optional: true
+    sugarss:
+      optional: true
+    terser:
+      optional: true
+    tsx:
+      optional: true
+    yaml:
+      optional: true
+  bin:
+    vite: bin/vite.js
+  checksum: 10/af65bf23dc346f968b8b2f577da4c5d18a5a21eea2ce699eb0018918151238ed185067de1749408d26ba93c743635c5870602bd77b4b6f2f678d8d685a9635d8
+  languageName: node
+  linkType: hard
+
 "vite@npm:^7.3.1":
   version: 7.3.5
   resolution: "vite@npm:7.3.5"
@@ -15750,6 +16312,74 @@ __metadata:
   bin:
     vite: bin/vite.js
   checksum: 10/2e1337510d6b81948b035f8b096c9be22daf1101fc52ad3d06cad9e090057ba1c1396e5e12cbaac2485f9c6cdcc854f978fe862280bdfe1a9a4149c60734c125
+  languageName: node
+  linkType: hard
+
+"vitest@npm:^4.1.10":
+  version: 4.1.10
+  resolution: "vitest@npm:4.1.10"
+  dependencies:
+    "@vitest/expect": "npm:4.1.10"
+    "@vitest/mocker": "npm:4.1.10"
+    "@vitest/pretty-format": "npm:4.1.10"
+    "@vitest/runner": "npm:4.1.10"
+    "@vitest/snapshot": "npm:4.1.10"
+    "@vitest/spy": "npm:4.1.10"
+    "@vitest/utils": "npm:4.1.10"
+    es-module-lexer: "npm:^2.0.0"
+    expect-type: "npm:^1.3.0"
+    magic-string: "npm:^0.30.21"
+    obug: "npm:^2.1.1"
+    pathe: "npm:^2.0.3"
+    picomatch: "npm:^4.0.3"
+    std-env: "npm:^4.0.0-rc.1"
+    tinybench: "npm:^2.9.0"
+    tinyexec: "npm:^1.0.2"
+    tinyglobby: "npm:^0.2.15"
+    tinyrainbow: "npm:^3.1.0"
+    vite: "npm:^6.0.0 || ^7.0.0 || ^8.0.0"
+    why-is-node-running: "npm:^2.3.0"
+  peerDependencies:
+    "@edge-runtime/vm": "*"
+    "@opentelemetry/api": ^1.9.0
+    "@types/node": ^20.0.0 || ^22.0.0 || >=24.0.0
+    "@vitest/browser-playwright": 4.1.10
+    "@vitest/browser-preview": 4.1.10
+    "@vitest/browser-webdriverio": 4.1.10
+    "@vitest/coverage-istanbul": 4.1.10
+    "@vitest/coverage-v8": 4.1.10
+    "@vitest/ui": 4.1.10
+    happy-dom: "*"
+    jsdom: "*"
+    vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+  peerDependenciesMeta:
+    "@edge-runtime/vm":
+      optional: true
+    "@opentelemetry/api":
+      optional: true
+    "@types/node":
+      optional: true
+    "@vitest/browser-playwright":
+      optional: true
+    "@vitest/browser-preview":
+      optional: true
+    "@vitest/browser-webdriverio":
+      optional: true
+    "@vitest/coverage-istanbul":
+      optional: true
+    "@vitest/coverage-v8":
+      optional: true
+    "@vitest/ui":
+      optional: true
+    happy-dom:
+      optional: true
+    jsdom:
+      optional: true
+    vite:
+      optional: false
+  bin:
+    vitest: ./vitest.mjs
+  checksum: 10/020843460fe696c23be2a363634dde4daf54625f1c443c24066ba3f87c478b0ccfdd5124343ba30eb092f54902ffea09f4bed0af4a16a9ee805e494ee2dce34e
   languageName: node
   linkType: hard
 
@@ -16225,6 +16855,18 @@ __metadata:
   bin:
     node-which: bin/which.js
   checksum: 10/dbea77c7d3058bf6c78bf9659d2dce4d2b57d39a15b826b2af6ac2e5a219b99dc8a831b79fdbc453c0598adb4f3f84cf9c2491fd52beb9f5d2dececcad117f68
+  languageName: node
+  linkType: hard
+
+"why-is-node-running@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "why-is-node-running@npm:2.3.0"
+  dependencies:
+    siginfo: "npm:^2.0.0"
+    stackback: "npm:0.0.2"
+  bin:
+    why-is-node-running: cli.js
+  checksum: 10/0de6e6cd8f2f94a8b5ca44e84cf1751eadcac3ebedcdc6e5fbbe6c8011904afcbc1a2777c53496ec02ced7b81f2e7eda61e76bf8262a8bc3ceaa1f6040508051
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Gadgetbridge never received anything: suncalc omits `rise`/`set` when the event does not happen that day (the moon skips a rise about once per lunar month, no sunrise at all during a polar night), so reading `.valueOf()` on the missing value threw. The catch swallowed it — release builds strip `console.*` — so no broadcast, no log, no message.
- The whole `WeatherSpec` payload moves out of Kotlin into a pure TS module (`app/services/gadgetbridgePayload.ts`), which makes it unit-testable on desktop. The native side is now transport only: gzip + broadcast.
- A broadcast failure is now surfaced to the user once per session instead of vanishing into a stripped `console.error`.
- Delivery fixes: `FLAG_INCLUDE_STOPPED_PACKAGES` restored (it was dropped when the per-package loop was added), all five documented Gadgetbridge package variants targeted, and the broadcast action declared in `<queries>` — targetSdk 36 filters package visibility.
- Payload fixes against Gadgetbridge's `WeatherSpec`: `moonPhase` in degrees `[0,360[` (was the app's 0..28 icon index), plus `latitude` / `longitude` / `isCurrentLocation`.

Note: sun/moon times are now computed on the UTC day (`inUTC = true`) instead of the device's local midnight — timezone-independent and deterministic under test.

## Testing

- `npx vitest run` — 9 cases in `app/services/gadgetbridgePayload.test.ts`. The repro case (Paris, 2026-01-10, a real day with no moonrise) was watched failing with `TypeError: Cannot read properties of undefined (reading 'valueOf')` before the fix.
- `npx eslint` clean on the touched files. `yarn svelte-check` reports only two pre-existing errors unrelated to this branch.
- Checked on device with Gadgetbridge installed: weather now goes through.

Fixes #491