### PR TITLE
fix(alerts): rework weather warnings and fix the empty alert sheet

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -50,6 +50,7 @@ Beyond those:
 
 - Prefer `const`/`let`, never `var`.
 - NEVER use a single-letter variable name — always prefer an explicit name.
+- Colors are ALWAYS hex (`#ffb82b`), never `rgb()`/`rgba()`. When a source gives separate channels, convert to hex before storing it.
 - Avoid `!` (non-null assertion) and `as SomeType` casts (`as const` is fine). Use type guards, narrowing, or restructured types instead.
 
 ## Native APIs

--- a/app/components/common/AlertView.svelte
+++ b/app/components/common/AlertView.svelte
@@ -1,26 +1,31 @@
 <script lang="ts">
     import { titlecase } from '@nativescript-community/l';
     import { Template } from '@nativescript-community/svelte-native/components';
+    import { Screen } from '@nativescript/core';
     import { formatDate, l } from '~/helpers/locale';
     import type { Alert } from '~/services//providers/weather';
-    import { colors } from '~/variables';
+    import { colors, windowInset } from '~/variables';
 
     export let alerts: Alert[];
+    // the sheet opens at its `peekHeight`; a full height content lets it expand up to the top while scrolling
+    $: sheetHeight = Screen.mainScreen.heightDIPs - $windowInset.top;
     $: ({ colorSurface, colorOnSurface, colorOnSurfaceVariant, colorPrimary, colorOutlineVariant } = $colors);
 </script>
 
-<collectionview id="scrollView" iosIgnoreSafeArea={true} items={alerts}>
-    <Template let:item>
-        <gridlayout>
-            <gridlayout backgroundColor={colorSurface} borderRadius={20} columns="auto,*" margin={10} padding="10 0 10 0" rows="auto">
-                <label class="icon-btn" color="#EFB644" fontSize={36} marginLeft={10} text="mdi-alert" verticalAlignment="top" />
-                <label col={1} fontSize={14} padding="0 4 4 0" textWrap={true}>
-                    <cspan fontSize={17} text={item.event} visibility={item.event ? 'visible' : 'hidden'} />
-                    <cspan fontSize={17} text={'\n' + item.sender_name} visibility={item.sender_name ? 'visible' : 'hidden'} />
-                    <cspan color={colorOnSurfaceVariant} text="{'\n' + titlecase(l('expires'))}: {formatDate(item.end, 'dddd LT', item.timezoneOffset)}" />
-                    <cspan color={colorOutlineVariant} text={'\n' + item.description} visibility={item.description?.length ? 'visible' : 'hidden'} />
-                </label>
+<gesturerootview rows="auto">
+    <collectionview id="scrollView" height={sheetHeight} iosIgnoreSafeArea={true} items={alerts}>
+        <Template let:item>
+            <gridlayout>
+                <gridlayout backgroundColor={colorSurface} borderRadius={20} columns="auto,*" margin={10} padding="10 0 10 0" rows="auto">
+                    <label class="icon-btn" color={item.color || '#EFB644'} fontSize={36} marginLeft={10} text="mdi-alert" verticalAlignment="top" />
+                    <label col={1} fontSize={14} padding="0 4 4 0" textWrap={true}>
+                        <cspan fontSize={17} text={item.event} visibility={item.event ? 'visible' : 'hidden'} />
+                        <cspan fontSize={17} text={'\n' + item.sender_name} visibility={item.sender_name ? 'visible' : 'hidden'} />
+                        <cspan color={colorOnSurfaceVariant} text="{'\n' + titlecase(l('expires'))}: {formatDate(item.end, 'dddd LT', item.timezoneOffset)}" />
+                        <cspan color={colorOutlineVariant} text={'\n' + item.description} visibility={item.description?.length ? 'visible' : 'hidden'} />
+                    </label>
+                </gridlayout>
             </gridlayout>
-        </gridlayout>
-    </Template>
-</collectionview>
+        </Template>
+    </collectionview>
+</gesturerootview>

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -375,6 +375,7 @@
   "waning_gibbous": "waning gibbous",
   "waxing_crescent": "waxing crescent",
   "waxing_gibbous": "waxing gibbous",
+  "weather_bulletin": "Weather bulletin",
   "weather_condition": "weather condition",
   "weather_data": "weather data",
   "weather_data_layout": "weather data layout for daily and top weather views",

--- a/app/i18n/fr.json
+++ b/app/i18n/fr.json
@@ -372,6 +372,7 @@
     "wave_height_max": "Hauteur max des vagues",
     "waxing_crescent": "premier croissant",
     "waxing_gibbous": "gibbeuse croissante",
+    "weather_bulletin": "Bulletin de vigilance",
     "weather_condition": "conditions météo",
     "weather_data": "données météo",
     "weather_data_layout": "mise en page des données météo pour les vues quotidiennes et au top",

--- a/app/services/providers/accuweather.ts
+++ b/app/services/providers/accuweather.ts
@@ -2,7 +2,8 @@ import { lc, titlecase } from '@nativescript-community/l';
 import { ApplicationSettings } from '@nativescript/core';
 import { WeatherDataType, weatherDataIconColors } from '~/helpers/formatter';
 import { getStartOfDay, lang } from '~/helpers/locale';
-import { WeatherLocation, request } from '../api';
+import { RequestResult, WeatherLocation, request } from '../api';
+import { buildAccuAlerts } from './alerts';
 import { WeatherProvider } from './weatherprovider';
 import { Currently, DailyData, Hourly, WeatherData } from './weather';
 import { FEELS_LIKE_TEMPERATURE, NB_DAYS_FORECAST, NB_HOURS_FORECAST } from '~/helpers/constants';
@@ -10,6 +11,38 @@ import { prefs } from '../preferences';
 import { AirQualityProvider } from './airqualityprovider';
 import { AirQualityData, CommonAirQualityData } from './weather';
 import { Pollutants } from '../airQualityData';
+
+/** `alerts/v1/geoposition` — only served on the paid AccuWeather plans. */
+export interface AccuWeatherAlert {
+    AlertID: number;
+    Description?: {
+        Localized?: string;
+        English?: string;
+    };
+    Category?: string;
+    /** 1 (most severe) to 5 */
+    Priority: number;
+    Type?: string;
+    Level?: string;
+    Color?: {
+        Red: number;
+        Green: number;
+        Blue: number;
+        Hex?: string;
+    };
+    Source?: string;
+    SourceId?: number;
+    Area?: AccuWeatherAlertArea[];
+}
+
+export interface AccuWeatherAlertArea {
+    /** seconds */
+    EpochStartTime?: number;
+    /** seconds */
+    EpochEndTime?: number;
+    Text?: string;
+    Summary?: string;
+}
 
 // Map AccuWeather icon codes to OpenWeatherMap-style icon codes for compatibility
 // AccuWeather uses 1-44 icon codes, we need to map to OWM style (e.g., 200-800)
@@ -127,6 +160,12 @@ export class AccuWeatherProvider extends WeatherProvider {
         // Fetch daily forecast (5 days)
         const dailyResult = await AccuWeatherProvider.fetch<any>(`forecasts/v1/daily/5day/${locationKey}`);
 
+        // Alerts are only served on the paid plans: never fail the whole forecast on them
+        const alertsResult =
+            warnings !== false
+                ? await AccuWeatherProvider.fetch<AccuWeatherAlert[]>('alerts/v1/geoposition', { q: `${coords.lat},${coords.lon}` }).catch(() => null as RequestResult<AccuWeatherAlert[]>)
+                : null;
+
         const r = {
             time: Date.now(),
             currently: weatherDataIconColors(
@@ -196,7 +235,7 @@ export class AccuWeatherProvider extends WeatherProvider {
             minutely: {
                 data: []
             },
-            alerts: []
+            alerts: buildAccuAlerts(alertsResult?.content)
         } as WeatherData;
 
         if (hourlyResult.content) {

--- a/app/services/providers/alerts.test.ts
+++ b/app/services/providers/alerts.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { AlertSeverity, buildAccuAlerts, colorFromSeverity, normalizeOwmAlerts, sortAlerts } from './alerts';
+import type { Alert } from './weather';
+
+describe('normalizeOwmAlerts', () => {
+    // One Call returns `start`/`end` as Unix seconds, the app works in milliseconds.
+    const OWM_ALERT = {
+        sender_name: 'Météo-France',
+        event: 'Canicule',
+        start: 1786380000,
+        end: 1786410000,
+        description: 'Vigilance orange canicule',
+        tags: ['Extreme high temperature']
+    };
+
+    it('converts seconds to milliseconds', () => {
+        const [alert] = normalizeOwmAlerts([OWM_ALERT]);
+        expect(alert.start).toBe(1786380000000);
+        expect(alert.end).toBe(1786410000000);
+    });
+
+    it('keeps the sender, event and description', () => {
+        const [alert] = normalizeOwmAlerts([OWM_ALERT]);
+        expect(alert.sender_name).toBe('Météo-France');
+        expect(alert.event).toBe('Canicule');
+        expect(alert.description).toBe('Vigilance orange canicule');
+    });
+
+    it('handles a missing alerts array', () => {
+        expect(normalizeOwmAlerts(undefined)).toEqual([]);
+    });
+});
+
+describe('buildAccuAlerts', () => {
+    const ACCU_ALERT = {
+        AlertID: 1234,
+        Description: { Localized: 'Heat Advisory', English: 'Heat Advisory' },
+        Category: 'heat',
+        Priority: 2,
+        Color: { Red: 255, Green: 184, Blue: 43, Hex: 'FFB82B' },
+        Source: 'Météo-France',
+        SourceId: 8,
+        Area: [{ EpochStartTime: 1786380000, EpochEndTime: 1786410000, Text: 'Stay hydrated.' }]
+    };
+
+    it('maps the AccuWeather payload onto the app alert', () => {
+        const [alert] = buildAccuAlerts([ACCU_ALERT]);
+        expect(alert.event).toBe('Heat Advisory');
+        expect(alert.description).toBe('Stay hydrated.');
+        expect(alert.sender_name).toBe('Météo-France');
+        expect(alert.start).toBe(1786380000000);
+        expect(alert.end).toBe(1786410000000);
+        expect(alert.color).toBe('#ffb82b');
+    });
+
+    it('maps priority onto severity', () => {
+        expect(buildAccuAlerts([{ ...ACCU_ALERT, Priority: 1 }])[0].severity).toBe(AlertSeverity.EXTREME);
+        expect(buildAccuAlerts([{ ...ACCU_ALERT, Priority: 3 }])[0].severity).toBe(AlertSeverity.MODERATE);
+        expect(buildAccuAlerts([{ ...ACCU_ALERT, Priority: 5 }])[0].severity).toBe(AlertSeverity.MINOR);
+        expect(buildAccuAlerts([{ ...ACCU_ALERT, Priority: 9 }])[0].severity).toBe(AlertSeverity.UNKNOWN);
+    });
+
+    it('handles a missing result list', () => {
+        expect(buildAccuAlerts(null)).toEqual([]);
+    });
+});
+
+describe('colorFromSeverity', () => {
+    it('uses a dense yellow, readable on both the light and the dark surface', () => {
+        expect(colorFromSeverity(AlertSeverity.MODERATE)).toBe('#cbd600');
+    });
+});
+
+describe('sortAlerts', () => {
+    it('sorts by decreasing severity then by start time', () => {
+        const alerts: Alert[] = [
+            { event: 'moderate', start: 30, end: 40, severity: AlertSeverity.MODERATE },
+            { event: 'extreme', start: 20, end: 40, severity: AlertSeverity.EXTREME },
+            { event: 'severe-late', start: 20, end: 40, severity: AlertSeverity.SEVERE },
+            { event: 'severe-early', start: 10, end: 40, severity: AlertSeverity.SEVERE }
+        ];
+        expect(sortAlerts(alerts).map((alert) => alert.event)).toEqual(['extreme', 'severe-early', 'severe-late', 'moderate']);
+    });
+});

--- a/app/services/providers/alerts.ts
+++ b/app/services/providers/alerts.ts
@@ -1,0 +1,132 @@
+import type { AccuWeatherAlert } from './accuweather';
+import type { Alert as OWMAlert } from './openweathermap';
+import type { Alert } from './weather';
+
+/**
+ * Weather alert helpers shared by every provider.
+ *
+ * Kept free of any NativeScript import so the mapping logic stays unit testable.
+ */
+
+export enum AlertSeverity {
+    UNKNOWN = 0,
+    MINOR = 1,
+    MODERATE = 2,
+    SEVERE = 3,
+    EXTREME = 4
+}
+
+export function colorFromSeverity(severity: AlertSeverity): string {
+    switch (severity) {
+        case AlertSeverity.EXTREME:
+            return '#cc0000';
+        case AlertSeverity.SEVERE:
+            return '#ffb82b';
+        case AlertSeverity.MODERATE:
+            return '#cbd600';
+        case AlertSeverity.MINOR:
+            return '#31aa35';
+        default:
+            return null;
+    }
+}
+
+/** Météo France vigilance level: 1 green, 2 yellow, 3 orange, 4 red. */
+export function severityFromVigilanceColorId(colorId: number): AlertSeverity {
+    switch (colorId) {
+        case 4:
+            return AlertSeverity.EXTREME;
+        case 3:
+            return AlertSeverity.SEVERE;
+        case 2:
+            return AlertSeverity.MODERATE;
+        case 1:
+            return AlertSeverity.MINOR;
+        default:
+            return AlertSeverity.UNKNOWN;
+    }
+}
+
+/** Overseas vigilance levels are only named, not numbered the same way as the metropolitan ones. */
+export function severityFromColorName(colorName: string): AlertSeverity {
+    const name = colorName?.toLowerCase() ?? '';
+    if (name.includes('rouge') || name.includes('violet')) {
+        return AlertSeverity.EXTREME;
+    }
+    if (name.includes('orange')) {
+        return AlertSeverity.SEVERE;
+    }
+    if (name.includes('jaune') || name.includes('blanc')) {
+        return AlertSeverity.MODERATE;
+    }
+    if (name.includes('vert') || name.includes('bleu')) {
+        return AlertSeverity.MINOR;
+    }
+    return AlertSeverity.UNKNOWN;
+}
+
+export function sortAlerts(alerts: Alert[]): Alert[] {
+    return alerts.sort((alert1, alert2) => (alert2.severity ?? AlertSeverity.UNKNOWN) - (alert1.severity ?? AlertSeverity.UNKNOWN) || alert1.start - alert2.start);
+}
+
+/** One Call gives `start`/`end` in seconds and no severity. */
+export function normalizeOwmAlerts(alerts: OWMAlert[]): Alert[] {
+    if (!alerts?.length) {
+        return [];
+    }
+    return alerts.map((alert) => ({
+        sender_name: alert.sender_name,
+        event: alert.event,
+        start: alert.start * 1000,
+        end: alert.end * 1000,
+        description: alert.description,
+        tags: alert.tags,
+        severity: AlertSeverity.UNKNOWN
+    }));
+}
+
+function hexFromChannels(red: number, green: number, blue: number): string {
+    return `#${[red, green, blue]
+        .map((channel) =>
+            Math.max(0, Math.min(255, Math.round(channel)))
+                .toString(16)
+                .padStart(2, '0')
+        )
+        .join('')}`;
+}
+
+function severityFromAccuPriority(priority: number): AlertSeverity {
+    switch (priority) {
+        case 1:
+            return AlertSeverity.EXTREME;
+        case 2:
+            return AlertSeverity.SEVERE;
+        case 3:
+            return AlertSeverity.MODERATE;
+        case 4:
+        case 5:
+            return AlertSeverity.MINOR;
+        default:
+            return AlertSeverity.UNKNOWN;
+    }
+}
+
+export function buildAccuAlerts(results: AccuWeatherAlert[]): Alert[] {
+    if (!results?.length) {
+        return [];
+    }
+    return results.map((result) => {
+        const severity = severityFromAccuPriority(result.Priority);
+        const area = result.Area?.[0];
+        const color = result.Color;
+        return {
+            sender_name: result.Source,
+            event: result.Description?.Localized,
+            start: area?.EpochStartTime ? area.EpochStartTime * 1000 : undefined,
+            end: area?.EpochEndTime ? area.EpochEndTime * 1000 : undefined,
+            description: area?.Text,
+            severity,
+            color: color ? hexFromChannels(color.Red, color.Green, color.Blue) : colorFromSeverity(severity)
+        };
+    });
+}

--- a/app/services/providers/meteofrance.d.ts
+++ b/app/services/providers/meteofrance.d.ts
@@ -136,12 +136,113 @@ interface MFWarnings {
     color_max: number;
     timelaps: Timelap[];
     phenomenons_items: Phenomenonsitem[];
-    advices?: any;
-    consequences?: any;
+    advices?: MFWarningAdvice[];
+    consequences?: MFWarningConsequence[];
     max_count_items?: any;
     comments: Comments;
-    text?: any;
-    text_avalanche?: any;
+    text?: MFWarningText;
+    text_avalanche?: MFWarningText;
+}
+
+interface MFWarningAdvice {
+    phenomenon_id: string;
+    phenomenon_max_color_id: number;
+    text_advice: string;
+}
+
+interface MFWarningConsequence {
+    phenomenon_id: string;
+    phenomenon_max_color_id: number;
+    text_consequence: string;
+}
+
+interface MFWarningSubdivisionText {
+    underline_text?: string;
+    bold_text?: string;
+    text?: string[];
+}
+
+interface MFWarningTermItem {
+    term_names?: string;
+    risk_name?: string;
+    start_time?: string;
+    end_time?: string;
+    subdivision_text?: MFWarningSubdivisionText[];
+}
+
+interface MFWarningTextItem {
+    type_code?: string;
+    /** phenomenon id the block is about, `null` for the general situation blocks */
+    hazard_code?: string;
+    hazard_name?: string;
+    term_items?: MFWarningTermItem[];
+}
+
+interface MFWarningTextBlocItem {
+    type_name?: string;
+    text_items?: MFWarningTextItem[];
+}
+
+interface MFWarningText {
+    bloc_title?: string;
+    text_bloc_item?: MFWarningTextBlocItem[];
+}
+
+/** `v2/warning/full`, used for overseas territories: phenomenon ids are numbers and the text is flat. */
+interface MFWarningsOverseas {
+    update_time: number;
+    end_validity_time: number;
+    domain_id: string;
+    color_max: number;
+    timelaps: MFOverseasTimelap[];
+    advices?: MFOverseasAdvice[];
+    consequences?: MFOverseasConsequence[];
+    comments?: MFOverseasText;
+    text?: MFOverseasText;
+}
+
+interface MFOverseasTimelap {
+    phenomenon_id: number;
+    timelaps_items: Timelapsitem[];
+}
+
+interface MFOverseasAdvice {
+    phenomenon_id: number;
+    text_advice: string;
+}
+
+interface MFOverseasConsequence {
+    phenomenon_id: number;
+    text_consequence: string;
+}
+
+interface MFOverseasText {
+    begin_time?: number;
+    end_time?: number;
+    text_bloc_item?: MFOverseasTextBlocItem[];
+}
+
+interface MFOverseasTextBlocItem {
+    title?: string;
+    text?: string[];
+}
+
+/** `v2/warning/dictionary`, gives the overseas phenomenon names and vigilance colors. */
+interface MFWarningDictionary {
+    phenomenons?: MFWarningDictionaryPhenomenon[];
+    colors?: MFWarningDictionaryColor[];
+}
+
+interface MFWarningDictionaryPhenomenon {
+    id: number;
+    name: string;
+}
+
+interface MFWarningDictionaryColor {
+    id: number;
+    level?: number;
+    name: string;
+    hexaCode: string;
 }
 
 interface Comments {

--- a/app/services/providers/mf.ts
+++ b/app/services/providers/mf.ts
@@ -4,7 +4,8 @@ import dayjs from 'dayjs';
 import { WeatherDataType, weatherDataIconColors } from '~/helpers/formatter';
 import { getEndOfDay, getStartOfDay, lang, lc } from '~/helpers/locale';
 import { RequestResult, WeatherLocation, request } from '../api';
-import type { Coord, Dailyforecast, ForecastForecast, MFCurrent, MFForecastResult, MFMinutely, MFWarnings, Probabilityforecast } from './meteofrance';
+import type { Coord, Dailyforecast, ForecastForecast, MFCurrent, MFForecastResult, MFMinutely, MFWarningDictionary, MFWarnings, MFWarningsOverseas, Probabilityforecast } from './meteofrance';
+import { MFWarningLabels, buildAlertsFromWarnings, buildOverseasAlerts, getMfDomain } from './mfWarnings';
 import { WeatherProvider } from './weatherprovider';
 import { Alert, Currently, DailyData, Hourly, MinutelyData, WeatherData } from './weather';
 import { ApplicationSettings } from '@nativescript/core';
@@ -17,6 +18,9 @@ const mfApiKey = getString('mfApiKey', MF_DEFAULT_KEY);
 
 interface MFParams extends Partial<Coord> {
     domain?: string;
+    /** `J0` (today) or `J1` (tomorrow), warnings only */
+    echeance?: string;
+    warning_type?: string;
 }
 
 const API_KEY_SETTING = 'mfApiKey';
@@ -332,21 +336,13 @@ export class MFProvider extends WeatherProvider {
         const forecast = result[0]?.content;
         const rain = result[1]?.content;
         const currentData = result[2]?.content;
-        let warningsData: MFWarnings;
-        if (warnings !== false && forecast.properties.french_department) {
-            warningsData = (
-                await this.fetch<MFWarnings>('v3/warning/full', {
-                    ...coords,
-                    domain: forecast.properties.french_department
-                }).catch((err) => null as RequestResult<MFWarnings>)
-            )?.content;
-        }
+        const now = Date.now();
+        const domain = warnings !== false ? getMfDomain(forecast.properties.french_department) : null;
+        const alerts = domain ? await this.getAlerts(domain, now) : [];
         // }
         // DEV_LOG && console.log('forecast', JSON.stringify(forecast));
         // DEV_LOG && console.log('rain', JSON.stringify(rain));
         // DEV_LOG && console.log('current', JSON.stringify(current));
-        // DEV_LOG && console.log('warningsData', JSON.stringify(warningsData));
-        const now = Date.now();
         const forecastData = forecast.properties.forecast;
         let hourlyData: Hourly[];
         if (forecastData) {
@@ -437,24 +433,44 @@ export class MFProvider extends WeatherProvider {
                             }) as MinutelyData
                     ) || []
             },
-            alerts: warningsData
-                ? warningsData.timelaps.reduce((acc, timelaps) => {
-                      timelaps.timelaps_items
-                          .filter((it) => it.color_id > 1 && it.end_time * 1000 > now)
-                          .forEach((w) => {
-                              acc.push({
-                                  start: w.begin_time * 1000,
-                                  end: w.end_time * 1000,
-                                  event: this.getWarningType(timelaps.phenomenon_id) + ' - ' + this.getWarningText(w.color_id),
-                                  description: w.color_id >= 1 ? this.getWarningContent(timelaps.phenomenon_id, warningsData) : undefined
-                              } as Alert);
-                          });
-                      return acc;
-                  }, [])
-                : []
+            alerts
         } as WeatherData;
         r.hourly = hourlyData || [];
         return r;
+    }
+
+    private get warningLabels(): MFWarningLabels {
+        return {
+            phenomenon: (phenomenonId) => this.getWarningType(phenomenonId),
+            level: (colorId) => this.getWarningText(colorId),
+            consequencesTitle: lc('possible_consequences'),
+            adviceTitle: lc('behavioral_tips'),
+            bulletinTitle: lc('weather_bulletin')
+        };
+    }
+
+    /**
+     * Metropolitan France publishes today (J0) and tomorrow (J1) on `v3`; overseas territories have
+     * their own `v2` endpoints, whose phenomenon names and colors come from a dictionary.
+     */
+    private async getAlerts(domain: string, now: number): Promise<Alert[]> {
+        if (domain.startsWith('VIGI')) {
+            const [warnings, dictionary] = await Promise.all([
+                this.fetch<MFWarningsOverseas>('v2/warning/full', {
+                    domain,
+                    // needed for La Réunion
+                    ...(domain === 'VIGI974' ? { warning_type: 'vigilance4colors' } : {})
+                }).catch(() => null as RequestResult<MFWarningsOverseas>),
+                this.fetch<MFWarningDictionary>('v2/warning/dictionary', { domain }).catch(() => null as RequestResult<MFWarningDictionary>)
+            ]);
+            return buildOverseasAlerts(warnings?.content, dictionary?.content, now, this.warningLabels);
+        }
+        const [today, tomorrow] = await Promise.all([
+            this.fetch<MFWarnings>('v3/warning/full', { domain, echeance: 'J0' }).catch(() => null as RequestResult<MFWarnings>),
+            // tomorrow is not published yet right after midnight
+            this.fetch<MFWarnings>('v3/warning/full', { domain, echeance: 'J1' }).catch(() => null as RequestResult<MFWarnings>)
+        ]);
+        return buildAlertsFromWarnings(today?.content, tomorrow?.content, now, this.warningLabels);
     }
 
     private getWarningType(phemononId: string) {
@@ -493,41 +509,6 @@ export class MFProvider extends WeatherProvider {
             default:
                 return lc('no_particular_vigilance');
         }
-    }
-
-    private getWarningColor(colorId: number) {
-        switch (colorId) {
-            case 4:
-                return 'rgb(204, 0, 0)';
-            case 3:
-                return 'rgb(255, 184, 43)';
-            case 2:
-                return 'rgb(255, 246, 0)';
-            case 1:
-                return 'rgb(49, 170, 53)';
-            default:
-                return null;
-        }
-    }
-
-    private getWarningContent(phenomenonId: string, warningsResult: MFWarnings): string {
-        const consequences = warningsResult.consequences?.some((it) => it.phenomenonId === phenomenonId)?.textConsequence?.replace('<br>', '\n');
-        const advices = warningsResult.advices?.some((it) => it.phenomenonId === phenomenonId)?.textAdvice?.replace('<br>', '\n');
-        let content = '';
-        if (consequences) {
-            content += lc('possible_consequences') + ':\n' + consequences;
-        }
-        if (advices) {
-            if (content.length) {
-                content += '\n';
-            }
-            content += lc('behavioral_tips') + ':\n' + advices;
-        }
-        // if (!content.length && warningsResult.comments?.text?.length) {
-        //     content = warningsResult.comments?.text[0];
-        // }
-        // There are also text blocks with hour by hour evaluation, but it’s way too detailed
-        return content.length ? content : null;
     }
 
     static apiKey = MFProvider.readApiKeySetting();

--- a/app/services/providers/mfWarnings.test.ts
+++ b/app/services/providers/mfWarnings.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from 'vitest';
+import { AlertSeverity, colorFromSeverity } from './alerts';
+import { MFWarningLabels, buildAlertsFromWarnings, buildOverseasAlerts, getMfDomain } from './mfWarnings';
+import type { MFWarningDictionary, MFWarnings, MFWarningsOverseas } from './meteofrance';
+
+// Fixtures follow the real `v3/warning/full` (metropolitan) and `v2/warning/full` (overseas)
+// payloads, trimmed to what the mapping reads.
+const NOW = 1786400000000;
+
+const LABELS: MFWarningLabels = {
+    phenomenon: (phenomenonId) => `phenomenon:${phenomenonId}`,
+    level: (colorId) => `level:${colorId}`,
+    consequencesTitle: 'Possible consequences',
+    adviceTitle: 'Behavioral tips',
+    bulletinTitle: 'Weather bulletin'
+};
+
+const BULLETIN_TEXT = {
+    bloc_title: 'Bulletin de suivi départemental de la Vigilance : Hérault (34)',
+    text_bloc_item: [
+        {
+            type_name: 'Situation météorologique',
+            text_items: [
+                {
+                    type_code: 'SITUATION_ZON_SITUATION_MÉTÉOROLOGIQUE',
+                    hazard_code: null,
+                    term_items: [
+                        {
+                            term_names: 'J+J1',
+                            risk_name: 'Orange',
+                            subdivision_text: [{ underline_text: '', bold_text: 'Faits nouveaux :', text: ['Entrée en vigilance orange Canicule.'] }]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            type_name: 'Suivi par phénomène',
+            text_items: [
+                {
+                    type_code: 'SUIVI_DEP_SUIVI_PHÉNOMÈNE_CA',
+                    hazard_code: '6',
+                    term_items: [
+                        {
+                            term_names: 'J+J1',
+                            risk_name: 'Orange',
+                            subdivision_text: [{ underline_text: '', bold_text: 'Qualification :', text: ['Épisode caniculaire durable.'] }]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+};
+
+// Yellow department: MF returns null advices/consequences, the text is only in `text`.
+const J0: MFWarnings = {
+    update_time: 1786390000,
+    end_validity_time: 1786410000,
+    domain_id: '34',
+    color_max: 2,
+    timelaps: [
+        { phenomenon_id: '6', timelaps_items: [{ begin_time: 1786380000, end_time: 1786410000, color_id: 2 }] },
+        { phenomenon_id: '1', timelaps_items: [{ begin_time: 1786380000, end_time: 1786410000, color_id: 1 }] },
+        { phenomenon_id: '3', timelaps_items: [{ begin_time: 1786300000, end_time: 1786390000, color_id: 3 }] }
+    ],
+    phenomenons_items: [],
+    advices: null,
+    consequences: null,
+    comments: { title: 'Commentaire carte', text: ['Épisode caniculaire sur le sud-est.'] },
+    text: BULLETIN_TEXT
+};
+
+// Tomorrow turns orange: advices/consequences are only populated from orange upwards.
+const J1: MFWarnings = {
+    update_time: 1786400500,
+    end_validity_time: 1786496400,
+    domain_id: '34',
+    color_max: 3,
+    timelaps: [
+        {
+            phenomenon_id: '6',
+            timelaps_items: [
+                { begin_time: 1786380000, end_time: 1786410000, color_id: 2 },
+                { begin_time: 1786410000, end_time: 1786496400, color_id: 3 }
+            ]
+        }
+    ],
+    phenomenons_items: [],
+    advices: [{ phenomenon_id: '6', phenomenon_max_color_id: 3, text_advice: '* Buvez de l’eau.<br>* Fermez les volets.' }],
+    consequences: [{ phenomenon_id: '6', phenomenon_max_color_id: 3, text_consequence: '* Chacun est menacé.<br>* Danger accru.' }],
+    comments: { title: 'Commentaire carte', text: ['Épisode caniculaire sur le sud-est.'] },
+    text: BULLETIN_TEXT
+};
+
+describe('getMfDomain', () => {
+    it('keeps metropolitan departments as-is', () => {
+        expect(getMfDomain('34')).toBe('34');
+        expect(getMfDomain('2A')).toBe('2A');
+    });
+    it('maps overseas territories to their VIGI domain', () => {
+        expect(getMfDomain('974')).toBe('VIGI974');
+        expect(getMfDomain('971')).toBe('VIGI971');
+    });
+    it('merges Saint-Barthélemy and Saint-Martin into a single domain', () => {
+        expect(getMfDomain('977')).toBe('VIGI978-977');
+        expect(getMfDomain('978')).toBe('VIGI978-977');
+    });
+    it('returns null for an unknown department', () => {
+        expect(getMfDomain('99')).toBeNull();
+        expect(getMfDomain('')).toBeNull();
+    });
+});
+
+describe('buildAlertsFromWarnings', () => {
+    it('drops green and expired vigilance', () => {
+        const alerts = buildAlertsFromWarnings(J0, null, NOW, LABELS);
+        expect(alerts.some((alert) => alert.event.includes('phenomenon:1'))).toBe(false);
+        expect(alerts.some((alert) => alert.event.includes('phenomenon:3'))).toBe(false);
+    });
+
+    it('builds the yellow description from the bulletin text blocks', () => {
+        const alerts = buildAlertsFromWarnings(J0, null, NOW, LABELS);
+        const yellow = alerts.find((alert) => alert.event === 'phenomenon:6 - level:2');
+        expect(yellow).toBeDefined();
+        expect(yellow.description).toContain('Qualification :');
+        expect(yellow.description).toContain('Épisode caniculaire durable.');
+        expect(yellow.severity).toBe(AlertSeverity.MODERATE);
+    });
+
+    it('builds the orange description from consequences and advices, converting every <br>', () => {
+        const alerts = buildAlertsFromWarnings(J0, J1, NOW, LABELS);
+        const orange = alerts.find((alert) => alert.event === 'phenomenon:6 - level:3');
+        expect(orange).toBeDefined();
+        expect(orange.description).toContain('Possible consequences');
+        expect(orange.description).toContain('Chacun est menacé.\n* Danger accru.');
+        expect(orange.description).toContain('Behavioral tips');
+        expect(orange.description).toContain('Buvez de l’eau.\n* Fermez les volets.');
+        expect(orange.description).not.toContain('<br>');
+        expect(orange.severity).toBe(AlertSeverity.SEVERE);
+    });
+
+    it('merges J0 and J1 without duplicating the shared vigilance', () => {
+        const alerts = buildAlertsFromWarnings(J0, J1, NOW, LABELS);
+        const shared = alerts.filter((alert) => alert.start === 1786380000000 && alert.event === 'phenomenon:6 - level:2');
+        expect(shared).toHaveLength(1);
+    });
+
+    it('exposes the bulletin first, keeping the longest validity', () => {
+        const alerts = buildAlertsFromWarnings(J0, J1, NOW, LABELS);
+        expect(alerts[0].event).toBe(BULLETIN_TEXT.bloc_title);
+        expect(alerts[0].severity).toBe(AlertSeverity.EXTREME);
+        expect(alerts[0].description).toContain('Faits nouveaux :');
+        expect(alerts[0].description).toContain('Entrée en vigilance orange Canicule.');
+        expect(alerts[0].end).toBe(1786496400000);
+        expect(alerts.filter((alert) => alert.event === BULLETIN_TEXT.bloc_title)).toHaveLength(1);
+    });
+
+    it('sorts the remaining alerts by decreasing severity', () => {
+        const alerts = buildAlertsFromWarnings(J0, J1, NOW, LABELS);
+        expect(alerts.map((alert) => alert.severity)).toEqual([AlertSeverity.EXTREME, AlertSeverity.SEVERE, AlertSeverity.MODERATE]);
+    });
+});
+
+const OVERSEAS: MFWarningsOverseas = {
+    update_time: 1786390000,
+    end_validity_time: 1786410000,
+    domain_id: 'VIGI974',
+    color_max: 3,
+    timelaps: [
+        {
+            phenomenon_id: 10,
+            timelaps_items: [
+                { begin_time: 1786380000, end_time: 1786410000, color_id: -1 },
+                { begin_time: 1786380000, end_time: 1786410000, color_id: 3 }
+            ]
+        }
+    ],
+    advices: null,
+    consequences: null,
+    text: {
+        begin_time: 1786362002,
+        end_time: null,
+        text_bloc_item: [{ title: 'Vagues-submersion', text: ['Pas de vigilance particulière.'] }]
+    }
+};
+
+const DICTIONARY: MFWarningDictionary = {
+    phenomenons: [
+        { id: 10, name: 'Alerte Cyclonique' },
+        { id: 9, name: 'Vagues-submersion' }
+    ],
+    colors: [
+        { id: 1, level: 1, name: 'vert', hexaCode: '#28d761' },
+        { id: 3, level: 3, name: 'orange hachuré', hexaCode: '#ff9900' }
+    ]
+};
+
+describe('buildOverseasAlerts', () => {
+    it('names phenomenons and levels from the dictionary', () => {
+        const alerts = buildOverseasAlerts(OVERSEAS, DICTIONARY, NOW, LABELS);
+        const cyclone = alerts.find((alert) => alert.event.startsWith('Alerte Cyclonique'));
+        expect(cyclone).toBeDefined();
+        expect(cyclone.event).toBe('Alerte Cyclonique - orange hachuré');
+        // the app palette wins over the dictionary color so every provider stays consistent
+        expect(cyclone.color).toBe(colorFromSeverity(AlertSeverity.SEVERE));
+        expect(cyclone.severity).toBe(AlertSeverity.SEVERE);
+    });
+
+    it('drops the undefined (-1) vigilance', () => {
+        const alerts = buildOverseasAlerts(OVERSEAS, DICTIONARY, NOW, LABELS);
+        expect(alerts.filter((alert) => alert.event.startsWith('Alerte Cyclonique'))).toHaveLength(1);
+    });
+
+    it('exposes the overseas bulletin', () => {
+        const alerts = buildOverseasAlerts(OVERSEAS, DICTIONARY, NOW, LABELS);
+        expect(alerts[0].event).toBe(LABELS.bulletinTitle);
+        expect(alerts[0].description).toContain('Vagues-submersion');
+        expect(alerts[0].description).toContain('Pas de vigilance particulière.');
+    });
+});

--- a/app/services/providers/mfWarnings.ts
+++ b/app/services/providers/mfWarnings.ts
@@ -1,0 +1,232 @@
+import { AlertSeverity, colorFromSeverity, severityFromColorName, severityFromVigilanceColorId, sortAlerts } from './alerts';
+import type { MFWarningDictionary, MFWarningText, MFWarnings, MFWarningsOverseas } from './meteofrance';
+import type { Alert } from './weather';
+
+/**
+ * Météo France vigilance mapping.
+ *
+ * Kept free of any NativeScript import so it stays unit testable: the localized labels are
+ * injected by the provider.
+ */
+
+export interface MFWarningLabels {
+    phenomenon(phenomenonId: string): string;
+    level(colorId: number): string;
+    consequencesTitle: string;
+    adviceTitle: string;
+    bulletinTitle: string;
+}
+
+/** Overseas territories are not served by `v3/warning/full`, they have their own `VIGI*` domain. */
+const OVERSEAS_TERRITORIES = ['971', '972', '973', '974', '975', '976', '977', '978', '986', '987', '988'];
+
+const METROPOLITAN_DEPARTMENT = /^(?:0[1-9]|[1-8]\d|9[0-5]|2[AB])$/;
+
+export function getMfDomain(frenchDepartment: string): string {
+    if (!frenchDepartment) {
+        return null;
+    }
+    if (METROPOLITAN_DEPARTMENT.test(frenchDepartment)) {
+        return frenchDepartment;
+    }
+    if (OVERSEAS_TERRITORIES.includes(frenchDepartment)) {
+        // Saint-Barthélemy and Saint-Martin share a single bulletin
+        return frenchDepartment === '977' || frenchDepartment === '978' ? 'VIGI978-977' : `VIGI${frenchDepartment}`;
+    }
+    return null;
+}
+
+function cleanupText(text: string): string {
+    return text?.replace(/<br\s*\/?>/gi, '\n').trim();
+}
+
+function appendSection(content: string[], title: string, text: string) {
+    const cleaned = cleanupText(text);
+    if (cleaned?.length) {
+        content.push(title ? `${title}:\n${cleaned}` : cleaned);
+    }
+}
+
+/**
+ * Bulletin text blocks, filtered on the phenomenon they describe. `hazard_code` is `null` on the
+ * general situation blocks, which is what the overall bulletin uses.
+ */
+function getTextBlocsContent(text: MFWarningText, phenomenonId: string): string[] {
+    const content: string[] = [];
+    text?.text_bloc_item?.forEach((blocItem) => {
+        const textItems = blocItem.text_items?.filter((textItem) => (textItem.hazard_code ?? null) === phenomenonId);
+        if (!textItems?.length) {
+            return;
+        }
+        const blocContent: string[] = [];
+        textItems.forEach((textItem) => {
+            textItem.term_items?.forEach((termItem) => {
+                termItem.subdivision_text?.forEach((subdivision) => {
+                    const parts: string[] = [];
+                    if (subdivision.underline_text?.length) {
+                        parts.push(subdivision.underline_text);
+                    }
+                    if (subdivision.bold_text?.length) {
+                        parts.push(subdivision.bold_text);
+                    }
+                    if (subdivision.text?.length) {
+                        parts.push(subdivision.text.join('\n'));
+                    }
+                    if (parts.length) {
+                        blocContent.push(parts.join(' '));
+                    }
+                });
+            });
+        });
+        if (blocContent.length) {
+            content.push(blocItem.type_name?.length ? `${blocItem.type_name}:\n${blocContent.join('\n\n')}` : blocContent.join('\n\n'));
+        }
+    });
+    return content;
+}
+
+/**
+ * MF only fills `consequences`/`advices` from the orange level upwards, the yellow ones only have
+ * the bulletin text blocks — so both sources are used.
+ */
+function getWarningContent(phenomenonId: string, warnings: MFWarnings, labels: MFWarningLabels): string {
+    const content = getTextBlocsContent(warnings.text, phenomenonId);
+    appendSection(content, labels.consequencesTitle, warnings.consequences?.find((it) => it.phenomenon_id === phenomenonId)?.text_consequence);
+    appendSection(content, labels.adviceTitle, warnings.advices?.find((it) => it.phenomenon_id === phenomenonId)?.text_advice);
+    return content.length ? content.join('\n\n') : null;
+}
+
+/** The overall vigilance bulletin: the text blocks that are not tied to a phenomenon. */
+function getBulletinAlert(warnings: MFWarnings, labels: MFWarningLabels): Alert {
+    if (!warnings?.text) {
+        return null;
+    }
+    const description = getWarningContent(null, warnings, labels);
+    if (!description) {
+        return null;
+    }
+    return {
+        start: warnings.update_time * 1000,
+        end: warnings.end_validity_time * 1000,
+        event: warnings.text.bloc_title?.length ? warnings.text.bloc_title : labels.bulletinTitle,
+        description,
+        // shown first: it summarizes every phenomenon, so it carries no vigilance color of its own
+        severity: AlertSeverity.EXTREME,
+        color: null
+    };
+}
+
+function getPhenomenonAlerts(warnings: MFWarnings, labels: MFWarningLabels): Alert[] {
+    if (!warnings?.timelaps) {
+        return [];
+    }
+    return warnings.timelaps.reduce((acc, timelaps) => {
+        timelaps.timelaps_items
+            ?.filter((item) => item.color_id > 1)
+            .forEach((item) => {
+                const severity = severityFromVigilanceColorId(item.color_id);
+                acc.push({
+                    start: item.begin_time * 1000,
+                    end: item.end_time * 1000,
+                    event: `${labels.phenomenon(timelaps.phenomenon_id)} - ${labels.level(item.color_id)}`,
+                    description: getWarningContent(timelaps.phenomenon_id, warnings, labels),
+                    severity,
+                    color: colorFromSeverity(severity)
+                });
+            });
+        return acc;
+    }, [] as Alert[]);
+}
+
+/**
+ * The same vigilance is published on both the J0 and the J1 bulletin, with a text that gets richer
+ * as the level rises. Alerts sharing an event over overlapping periods are merged into a single one
+ * covering the whole period, keeping the most detailed text.
+ */
+function dedupeAlerts(alerts: Alert[]): Alert[] {
+    const merged: Alert[] = [];
+    alerts.forEach((alert) => {
+        const existing = merged.find((candidate) => candidate.event === alert.event && alert.start <= candidate.end && alert.end >= candidate.start);
+        if (existing) {
+            existing.start = Math.min(existing.start, alert.start);
+            existing.end = Math.max(existing.end, alert.end);
+            if ((alert.description?.length ?? 0) > (existing.description?.length ?? 0)) {
+                existing.description = alert.description;
+            }
+            return;
+        }
+        merged.push({ ...alert });
+    });
+    return merged;
+}
+
+/**
+ * @param today `v3/warning/full` for `echeance=J0`
+ * @param tomorrow same for `echeance=J1`, `null` when it is not published yet
+ */
+export function buildAlertsFromWarnings(today: MFWarnings, tomorrow: MFWarnings, now: number, labels: MFWarningLabels): Alert[] {
+    const alerts = [today, tomorrow]
+        .filter((warnings) => !!warnings)
+        .reduce((acc, warnings) => {
+            const bulletin = getBulletinAlert(warnings, labels);
+            if (bulletin) {
+                acc.push(bulletin);
+            }
+            return acc.concat(getPhenomenonAlerts(warnings, labels));
+        }, [] as Alert[]);
+    return sortAlerts(dedupeAlerts(alerts).filter((alert) => alert.end > now));
+}
+
+function getOverseasBulletinAlert(warnings: MFWarningsOverseas, labels: MFWarningLabels): Alert {
+    const blocItems = warnings?.text?.text_bloc_item;
+    // unlike the metropolitan bulletin, the overseas one is always published, even when every
+    // phenomenon is green — only show it once something is actually going on
+    if (!blocItems?.length || !(warnings.color_max > 1)) {
+        return null;
+    }
+    const description = blocItems
+        .map((blocItem) => [blocItem.title, blocItem.text?.join('\n')].filter((part) => part?.length).join('\n'))
+        .filter((part) => part.length)
+        .join('\n\n');
+    if (!description.length) {
+        return null;
+    }
+    return {
+        start: warnings.text.begin_time * 1000,
+        end: (warnings.text.end_time ?? warnings.end_validity_time) * 1000,
+        event: labels.bulletinTitle,
+        description: cleanupText(description),
+        severity: AlertSeverity.EXTREME,
+        color: null
+    };
+}
+
+export function buildOverseasAlerts(warnings: MFWarningsOverseas, dictionary: MFWarningDictionary, now: number, labels: MFWarningLabels): Alert[] {
+    if (!warnings) {
+        return [];
+    }
+    const alerts: Alert[] = [];
+    const bulletin = getOverseasBulletinAlert(warnings, labels);
+    if (bulletin) {
+        alerts.push(bulletin);
+    }
+    warnings.timelaps?.forEach((timelaps) => {
+        const phenomenonName = dictionary?.phenomenons?.find((phenomenon) => phenomenon.id === timelaps.phenomenon_id)?.name ?? labels.phenomenon(`${timelaps.phenomenon_id}`);
+        timelaps.timelaps_items
+            ?.filter((item) => item.color_id > 1)
+            .forEach((item) => {
+                const color = dictionary?.colors?.find((dictionaryColor) => dictionaryColor.id === item.color_id);
+                const severity = color ? severityFromColorName(color.name) : severityFromVigilanceColorId(item.color_id);
+                alerts.push({
+                    start: item.begin_time * 1000,
+                    end: item.end_time * 1000,
+                    event: `${phenomenonName} - ${color?.name ?? labels.level(item.color_id)}`,
+                    description: cleanupText(warnings.consequences?.find((it) => it.phenomenon_id === timelaps.phenomenon_id)?.text_consequence),
+                    severity,
+                    // the app palette wins over the dictionary color so every provider stays consistent
+                    color: colorFromSeverity(severity) ?? color?.hexaCode
+                });
+            });
+    });
+    return sortAlerts(dedupeAlerts(alerts).filter((alert) => alert.end > now));
+}

--- a/app/services/providers/owm.ts
+++ b/app/services/providers/owm.ts
@@ -5,6 +5,7 @@ import { WeatherDataType, weatherDataIconColors } from '~/helpers/formatter';
 import { getStartOfDay, lang } from '~/helpers/locale';
 import { WeatherLocation, request } from '../api';
 import { prefs } from '../preferences';
+import { normalizeOwmAlerts } from './alerts';
 import { CityWeather, Coord, OneCallResult } from './openweathermap';
 import { Currently, DailyData, Hourly, WeatherData } from './weather';
 import { WeatherProvider } from './weatherprovider';
@@ -135,7 +136,7 @@ export class OWMProvider extends WeatherProvider {
                         }))
                         .filter((d, i) => i % 5 === 0) || []
             },
-            alerts: forecast.alerts
+            alerts: normalizeOwmAlerts(forecast.alerts)
         } as WeatherData;
         if (forecast.hourly) {
             const hourlyLastIndex = Math.min(forecast.hourly.length, forecast_hours) - 1;

--- a/app/services/providers/weather.d.ts
+++ b/app/services/providers/weather.d.ts
@@ -1,4 +1,5 @@
 import { Color } from '@nativescript/core';
+import { AlertSeverity } from './alerts';
 import { aqi_providers, marine_providers, providers } from './weatherproviderfactory';
 import { UNIT_FAMILIES } from '~/helpers/units';
 // import { Pollutants } from '../airQualityData';
@@ -43,9 +44,14 @@ export interface MarineWeatherData {
 export interface Alert {
     sender_name?: string;
     event: string;
+    /** milliseconds */
     start: number;
+    /** milliseconds */
     end: number;
-    description: string;
+    description?: string;
+    severity?: AlertSeverity;
+    /** color of the alert level, as given by the provider or derived from `severity` */
+    color?: string;
     tags?: string[];
 }
 


### PR DESCRIPTION
## Summary

- **Fix the alert sheet never showing (#485).** `AlertView` was a bare `collectionview` with no height — the only bottom sheet view in the repo not wrapped in a layout. On Android its content measured 0, so tapping ⚠ opened nothing (no error either). It now sits in a `gesturerootview` with a full height, so the sheet opens at its peek height and expands to the top while scrolling.
- **Rebuild the Météo France warnings mapping.** `getWarningContent` used `Array.some()` as a lookup and read camelCase keys the API never returns, so every alert description was `null`. The mapping moved to a pure, unit-tested module, aligned on the [BreezyWeather](https://github.com/breezy-weather/breezy-weather) implementation, and now covers what the app was missing: the vigilance bulletin, tomorrow's vigilance (`echeance=J1`), and the overseas `VIGI*` domains with their phenomenon/color dictionary. Alerts published on both bulletins are merged instead of duplicated.
- **Fix the other providers.** OpenWeather alerts were passed straight through with One Call's second timestamps while the app expects milliseconds (every alert expired in 1970); AccuWeather alerts were hardcoded to `[]` and are now fetched from `alerts/v1/geoposition`, fail-soft since that endpoint is paid-plan only.
- **Alerts carry a severity and a color**, so the ⚠ icon reflects the vigilance level instead of a single fixed amber.

Open-Meteo has no alert API and keeps returning `[]`.

## Testing

- `npx vitest run app` — 30 tests, including 20 new ones on the two pure modules, built from real MF payloads (yellow department with `null` advices, orange with populated ones, J0/J1 merge, overseas + dictionary).
- Cross-checked against the live MF API: Hérault returned the bulletin, the orange heat wave for tomorrow, the yellow one for today and two thunderstorm windows, with full text. A green department returns no alert at all, so the ⚠ button stays hidden.
- Ran on device: the sheet opens and the warnings display.

Still needs a visual pass on device, on top of what was already checked:

- long alerts: start scrolling, the sheet should expand up to the top;
- the new yellow on a location with both a yellow and an orange vigilance (Lyon `45.7580, 4.8351` or Nîmes `43.8322, 4.3429` right now);
- an overseas location for the `VIGI*` path.

Fixes #485