### PR TITLE
refactor(providers): let each provider own its alerts

### DIFF
--- a/app/services/providers/accuAlerts.test.ts
+++ b/app/services/providers/accuAlerts.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { buildAccuAlerts } from './accuAlerts';
+import { AlertSeverity } from './alerts';
+
+describe('buildAccuAlerts', () => {
+    const ACCU_ALERT = {
+        AlertID: 1234,
+        Description: { Localized: 'Heat Advisory', English: 'Heat Advisory' },
+        Category: 'heat',
+        Priority: 2,
+        Color: { Red: 255, Green: 184, Blue: 43, Hex: 'FFB82B' },
+        Source: 'Météo-France',
+        SourceId: 8,
+        Area: [{ EpochStartTime: 1786380000, EpochEndTime: 1786410000, Text: 'Stay hydrated.' }]
+    };
+
+    it('maps the AccuWeather payload onto the app alert', () => {
+        const [alert] = buildAccuAlerts([ACCU_ALERT]);
+        expect(alert.event).toBe('Heat Advisory');
+        expect(alert.description).toBe('Stay hydrated.');
+        expect(alert.sender_name).toBe('Météo-France');
+        expect(alert.start).toBe(1786380000000);
+        expect(alert.end).toBe(1786410000000);
+        expect(alert.color).toBe('#ffb82b');
+    });
+
+    it('maps priority onto severity', () => {
+        expect(buildAccuAlerts([{ ...ACCU_ALERT, Priority: 1 }])[0].severity).toBe(AlertSeverity.EXTREME);
+        expect(buildAccuAlerts([{ ...ACCU_ALERT, Priority: 3 }])[0].severity).toBe(AlertSeverity.MODERATE);
+        expect(buildAccuAlerts([{ ...ACCU_ALERT, Priority: 5 }])[0].severity).toBe(AlertSeverity.MINOR);
+        expect(buildAccuAlerts([{ ...ACCU_ALERT, Priority: 9 }])[0].severity).toBe(AlertSeverity.UNKNOWN);
+    });
+
+    it('handles a missing result list', () => {
+        expect(buildAccuAlerts(null)).toEqual([]);
+    });
+});

--- a/app/services/providers/accuAlerts.ts
+++ b/app/services/providers/accuAlerts.ts
@@ -1,0 +1,41 @@
+import type { AccuWeatherAlert } from './accuweather';
+import { AlertSeverity, colorFromSeverity, hexFromChannels } from './alerts';
+import type { Alert } from './weather';
+
+/** AccuWeather alert mapping. Kept out of `accuweather.ts` so it stays unit testable. */
+
+function severityFromPriority(priority: number): AlertSeverity {
+    switch (priority) {
+        case 1:
+            return AlertSeverity.EXTREME;
+        case 2:
+            return AlertSeverity.SEVERE;
+        case 3:
+            return AlertSeverity.MODERATE;
+        case 4:
+        case 5:
+            return AlertSeverity.MINOR;
+        default:
+            return AlertSeverity.UNKNOWN;
+    }
+}
+
+export function buildAccuAlerts(results: AccuWeatherAlert[]): Alert[] {
+    if (!results?.length) {
+        return [];
+    }
+    return results.map((result) => {
+        const severity = severityFromPriority(result.Priority);
+        const area = result.Area?.[0];
+        const color = result.Color;
+        return {
+            sender_name: result.Source,
+            event: result.Description?.Localized,
+            start: area?.EpochStartTime ? area.EpochStartTime * 1000 : undefined,
+            end: area?.EpochEndTime ? area.EpochEndTime * 1000 : undefined,
+            description: area?.Text,
+            severity,
+            color: color ? hexFromChannels(color.Red, color.Green, color.Blue) : colorFromSeverity(severity)
+        };
+    });
+}

--- a/app/services/providers/accuweather.ts
+++ b/app/services/providers/accuweather.ts
@@ -3,9 +3,9 @@ import { ApplicationSettings } from '@nativescript/core';
 import { WeatherDataType, weatherDataIconColors } from '~/helpers/formatter';
 import { getStartOfDay, lang } from '~/helpers/locale';
 import { RequestResult, WeatherLocation, request } from '../api';
-import { buildAccuAlerts } from './alerts';
-import { WeatherProvider } from './weatherprovider';
-import { Currently, DailyData, Hourly, WeatherData } from './weather';
+import { buildAccuAlerts } from './accuAlerts';
+import { GetWeatherOptions, WeatherProvider } from './weatherprovider';
+import { Alert, Currently, DailyData, Hourly, WeatherData } from './weather';
 import { FEELS_LIKE_TEMPERATURE, NB_DAYS_FORECAST, NB_HOURS_FORECAST } from '~/helpers/constants';
 import { prefs } from '../preferences';
 import { AirQualityProvider } from './airqualityprovider';
@@ -141,6 +141,13 @@ export class AccuWeatherProvider extends WeatherProvider {
         return result.content.Key;
     }
 
+    /** `alerts/v1/geoposition` is only served on the paid plans: never fail the whole forecast on it. */
+    public override async getAlerts(weatherLocation: WeatherLocation, options?: GetWeatherOptions): Promise<Alert[]> {
+        const coords = weatherLocation.coord;
+        const result = await AccuWeatherProvider.fetch<AccuWeatherAlert[]>('alerts/v1/geoposition', { q: `${coords.lat},${coords.lon}` }).catch(() => null as RequestResult<AccuWeatherAlert[]>);
+        return buildAccuAlerts(result?.content);
+    }
+
     public override async getWeather(weatherLocation: WeatherLocation, { current, minutely, warnings }: { warnings?: boolean; minutely?: boolean; current?: boolean } = {}) {
         const coords = weatherLocation.coord;
         const feelsLikeTemperatures = ApplicationSettings.getBoolean('feels_like_temperatures', FEELS_LIKE_TEMPERATURE);
@@ -160,11 +167,7 @@ export class AccuWeatherProvider extends WeatherProvider {
         // Fetch daily forecast (5 days)
         const dailyResult = await AccuWeatherProvider.fetch<any>(`forecasts/v1/daily/5day/${locationKey}`);
 
-        // Alerts are only served on the paid plans: never fail the whole forecast on them
-        const alertsResult =
-            warnings !== false
-                ? await AccuWeatherProvider.fetch<AccuWeatherAlert[]>('alerts/v1/geoposition', { q: `${coords.lat},${coords.lon}` }).catch(() => null as RequestResult<AccuWeatherAlert[]>)
-                : null;
+        const alerts = warnings !== false ? await this.getAlerts(weatherLocation, { warnings }) : [];
 
         const r = {
             time: Date.now(),
@@ -235,7 +238,7 @@ export class AccuWeatherProvider extends WeatherProvider {
             minutely: {
                 data: []
             },
-            alerts: buildAccuAlerts(alertsResult?.content)
+            alerts
         } as WeatherData;
 
         if (hourlyResult.content) {

--- a/app/services/providers/alerts.test.ts
+++ b/app/services/providers/alerts.test.ts
@@ -1,73 +1,17 @@
 import { describe, expect, it } from 'vitest';
-import { AlertSeverity, buildAccuAlerts, colorFromSeverity, normalizeOwmAlerts, sortAlerts } from './alerts';
+import { AlertSeverity, colorFromSeverity, hexFromChannels, sortAlerts } from './alerts';
 import type { Alert } from './weather';
-
-describe('normalizeOwmAlerts', () => {
-    // One Call returns `start`/`end` as Unix seconds, the app works in milliseconds.
-    const OWM_ALERT = {
-        sender_name: 'Météo-France',
-        event: 'Canicule',
-        start: 1786380000,
-        end: 1786410000,
-        description: 'Vigilance orange canicule',
-        tags: ['Extreme high temperature']
-    };
-
-    it('converts seconds to milliseconds', () => {
-        const [alert] = normalizeOwmAlerts([OWM_ALERT]);
-        expect(alert.start).toBe(1786380000000);
-        expect(alert.end).toBe(1786410000000);
-    });
-
-    it('keeps the sender, event and description', () => {
-        const [alert] = normalizeOwmAlerts([OWM_ALERT]);
-        expect(alert.sender_name).toBe('Météo-France');
-        expect(alert.event).toBe('Canicule');
-        expect(alert.description).toBe('Vigilance orange canicule');
-    });
-
-    it('handles a missing alerts array', () => {
-        expect(normalizeOwmAlerts(undefined)).toEqual([]);
-    });
-});
-
-describe('buildAccuAlerts', () => {
-    const ACCU_ALERT = {
-        AlertID: 1234,
-        Description: { Localized: 'Heat Advisory', English: 'Heat Advisory' },
-        Category: 'heat',
-        Priority: 2,
-        Color: { Red: 255, Green: 184, Blue: 43, Hex: 'FFB82B' },
-        Source: 'Météo-France',
-        SourceId: 8,
-        Area: [{ EpochStartTime: 1786380000, EpochEndTime: 1786410000, Text: 'Stay hydrated.' }]
-    };
-
-    it('maps the AccuWeather payload onto the app alert', () => {
-        const [alert] = buildAccuAlerts([ACCU_ALERT]);
-        expect(alert.event).toBe('Heat Advisory');
-        expect(alert.description).toBe('Stay hydrated.');
-        expect(alert.sender_name).toBe('Météo-France');
-        expect(alert.start).toBe(1786380000000);
-        expect(alert.end).toBe(1786410000000);
-        expect(alert.color).toBe('#ffb82b');
-    });
-
-    it('maps priority onto severity', () => {
-        expect(buildAccuAlerts([{ ...ACCU_ALERT, Priority: 1 }])[0].severity).toBe(AlertSeverity.EXTREME);
-        expect(buildAccuAlerts([{ ...ACCU_ALERT, Priority: 3 }])[0].severity).toBe(AlertSeverity.MODERATE);
-        expect(buildAccuAlerts([{ ...ACCU_ALERT, Priority: 5 }])[0].severity).toBe(AlertSeverity.MINOR);
-        expect(buildAccuAlerts([{ ...ACCU_ALERT, Priority: 9 }])[0].severity).toBe(AlertSeverity.UNKNOWN);
-    });
-
-    it('handles a missing result list', () => {
-        expect(buildAccuAlerts(null)).toEqual([]);
-    });
-});
 
 describe('colorFromSeverity', () => {
     it('uses a dense yellow, readable on both the light and the dark surface', () => {
         expect(colorFromSeverity(AlertSeverity.MODERATE)).toBe('#cbd600');
+    });
+});
+
+describe('hexFromChannels', () => {
+    it('pads and clamps each channel', () => {
+        expect(hexFromChannels(255, 184, 43)).toBe('#ffb82b');
+        expect(hexFromChannels(0, 5, 300)).toBe('#0005ff');
     });
 });
 

--- a/app/services/providers/alerts.ts
+++ b/app/services/providers/alerts.ts
@@ -1,11 +1,10 @@
-import type { AccuWeatherAlert } from './accuweather';
-import type { Alert as OWMAlert } from './openweathermap';
 import type { Alert } from './weather';
 
 /**
- * Weather alert helpers shared by every provider.
+ * Provider-agnostic weather alert helpers. Mapping a provider payload onto an `Alert` belongs to
+ * that provider, not here.
  *
- * Kept free of any NativeScript import so the mapping logic stays unit testable.
+ * Kept free of any NativeScript import so the logic stays unit testable.
  */
 
 export enum AlertSeverity {
@@ -31,61 +30,8 @@ export function colorFromSeverity(severity: AlertSeverity): string {
     }
 }
 
-/** Météo France vigilance level: 1 green, 2 yellow, 3 orange, 4 red. */
-export function severityFromVigilanceColorId(colorId: number): AlertSeverity {
-    switch (colorId) {
-        case 4:
-            return AlertSeverity.EXTREME;
-        case 3:
-            return AlertSeverity.SEVERE;
-        case 2:
-            return AlertSeverity.MODERATE;
-        case 1:
-            return AlertSeverity.MINOR;
-        default:
-            return AlertSeverity.UNKNOWN;
-    }
-}
-
-/** Overseas vigilance levels are only named, not numbered the same way as the metropolitan ones. */
-export function severityFromColorName(colorName: string): AlertSeverity {
-    const name = colorName?.toLowerCase() ?? '';
-    if (name.includes('rouge') || name.includes('violet')) {
-        return AlertSeverity.EXTREME;
-    }
-    if (name.includes('orange')) {
-        return AlertSeverity.SEVERE;
-    }
-    if (name.includes('jaune') || name.includes('blanc')) {
-        return AlertSeverity.MODERATE;
-    }
-    if (name.includes('vert') || name.includes('bleu')) {
-        return AlertSeverity.MINOR;
-    }
-    return AlertSeverity.UNKNOWN;
-}
-
-export function sortAlerts(alerts: Alert[]): Alert[] {
-    return alerts.sort((alert1, alert2) => (alert2.severity ?? AlertSeverity.UNKNOWN) - (alert1.severity ?? AlertSeverity.UNKNOWN) || alert1.start - alert2.start);
-}
-
-/** One Call gives `start`/`end` in seconds and no severity. */
-export function normalizeOwmAlerts(alerts: OWMAlert[]): Alert[] {
-    if (!alerts?.length) {
-        return [];
-    }
-    return alerts.map((alert) => ({
-        sender_name: alert.sender_name,
-        event: alert.event,
-        start: alert.start * 1000,
-        end: alert.end * 1000,
-        description: alert.description,
-        tags: alert.tags,
-        severity: AlertSeverity.UNKNOWN
-    }));
-}
-
-function hexFromChannels(red: number, green: number, blue: number): string {
+/** For the providers giving a color as separate channels. */
+export function hexFromChannels(red: number, green: number, blue: number): string {
     return `#${[red, green, blue]
         .map((channel) =>
             Math.max(0, Math.min(255, Math.round(channel)))
@@ -95,38 +41,6 @@ function hexFromChannels(red: number, green: number, blue: number): string {
         .join('')}`;
 }
 
-function severityFromAccuPriority(priority: number): AlertSeverity {
-    switch (priority) {
-        case 1:
-            return AlertSeverity.EXTREME;
-        case 2:
-            return AlertSeverity.SEVERE;
-        case 3:
-            return AlertSeverity.MODERATE;
-        case 4:
-        case 5:
-            return AlertSeverity.MINOR;
-        default:
-            return AlertSeverity.UNKNOWN;
-    }
-}
-
-export function buildAccuAlerts(results: AccuWeatherAlert[]): Alert[] {
-    if (!results?.length) {
-        return [];
-    }
-    return results.map((result) => {
-        const severity = severityFromAccuPriority(result.Priority);
-        const area = result.Area?.[0];
-        const color = result.Color;
-        return {
-            sender_name: result.Source,
-            event: result.Description?.Localized,
-            start: area?.EpochStartTime ? area.EpochStartTime * 1000 : undefined,
-            end: area?.EpochEndTime ? area.EpochEndTime * 1000 : undefined,
-            description: area?.Text,
-            severity,
-            color: color ? hexFromChannels(color.Red, color.Green, color.Blue) : colorFromSeverity(severity)
-        };
-    });
+export function sortAlerts(alerts: Alert[]): Alert[] {
+    return alerts.sort((alert1, alert2) => (alert2.severity ?? AlertSeverity.UNKNOWN) - (alert1.severity ?? AlertSeverity.UNKNOWN) || alert1.start - alert2.start);
 }

--- a/app/services/providers/mf.ts
+++ b/app/services/providers/mf.ts
@@ -6,7 +6,7 @@ import { getEndOfDay, getStartOfDay, lang, lc } from '~/helpers/locale';
 import { RequestResult, WeatherLocation, request } from '../api';
 import type { Coord, Dailyforecast, ForecastForecast, MFCurrent, MFForecastResult, MFMinutely, MFWarningDictionary, MFWarnings, MFWarningsOverseas, Probabilityforecast } from './meteofrance';
 import { MFWarningLabels, buildAlertsFromWarnings, buildOverseasAlerts, getMfDomain } from './mfWarnings';
-import { WeatherProvider } from './weatherprovider';
+import { GetWeatherOptions, WeatherProvider } from './weatherprovider';
 import { Alert, Currently, DailyData, Hourly, MinutelyData, WeatherData } from './weather';
 import { ApplicationSettings } from '@nativescript/core';
 import { NB_DAYS_FORECAST, NB_HOURS_FORECAST, NB_MINUTES_FORECAST } from '~/helpers/constants';
@@ -337,8 +337,7 @@ export class MFProvider extends WeatherProvider {
         const rain = result[1]?.content;
         const currentData = result[2]?.content;
         const now = Date.now();
-        const domain = warnings !== false ? getMfDomain(forecast.properties.french_department) : null;
-        const alerts = domain ? await this.getAlerts(domain, now) : [];
+        const alerts = warnings !== false ? await this.getAlerts(weatherLocation, { warnings }, forecast) : [];
         // }
         // DEV_LOG && console.log('forecast', JSON.stringify(forecast));
         // DEV_LOG && console.log('rain', JSON.stringify(rain));
@@ -452,8 +451,17 @@ export class MFProvider extends WeatherProvider {
     /**
      * Metropolitan France publishes today (J0) and tomorrow (J1) on `v3`; overseas territories have
      * their own `v2` endpoints, whose phenomenon names and colors come from a dictionary.
+     *
+     * @param forecast the `v2/forecast` payload when `getWeather` already fetched it: it carries the
+     * department the vigilance domain is derived from
      */
-    private async getAlerts(domain: string, now: number): Promise<Alert[]> {
+    public override async getAlerts(weatherLocation: WeatherLocation, options?: GetWeatherOptions, forecast?: MFForecastResult): Promise<Alert[]> {
+        const properties = forecast ? forecast.properties : (await this.fetch<MFForecastResult>('v2/forecast', weatherLocation.coord))?.content?.properties;
+        const domain = getMfDomain(properties?.french_department);
+        if (!domain) {
+            return [];
+        }
+        const now = Date.now();
         if (domain.startsWith('VIGI')) {
             const [warnings, dictionary] = await Promise.all([
                 this.fetch<MFWarningsOverseas>('v2/warning/full', {

--- a/app/services/providers/mfWarnings.ts
+++ b/app/services/providers/mfWarnings.ts
@@ -1,4 +1,4 @@
-import { AlertSeverity, colorFromSeverity, severityFromColorName, severityFromVigilanceColorId, sortAlerts } from './alerts';
+import { AlertSeverity, colorFromSeverity, sortAlerts } from './alerts';
 import type { MFWarningDictionary, MFWarningText, MFWarnings, MFWarningsOverseas } from './meteofrance';
 import type { Alert } from './weather';
 
@@ -15,6 +15,40 @@ export interface MFWarningLabels {
     consequencesTitle: string;
     adviceTitle: string;
     bulletinTitle: string;
+}
+
+/** Metropolitan vigilance level: 1 green, 2 yellow, 3 orange, 4 red. */
+export function severityFromVigilanceColorId(colorId: number): AlertSeverity {
+    switch (colorId) {
+        case 4:
+            return AlertSeverity.EXTREME;
+        case 3:
+            return AlertSeverity.SEVERE;
+        case 2:
+            return AlertSeverity.MODERATE;
+        case 1:
+            return AlertSeverity.MINOR;
+        default:
+            return AlertSeverity.UNKNOWN;
+    }
+}
+
+/** Overseas vigilance levels are only named, not numbered the same way as the metropolitan ones. */
+export function severityFromColorName(colorName: string): AlertSeverity {
+    const name = colorName?.toLowerCase() ?? '';
+    if (name.includes('rouge') || name.includes('violet')) {
+        return AlertSeverity.EXTREME;
+    }
+    if (name.includes('orange')) {
+        return AlertSeverity.SEVERE;
+    }
+    if (name.includes('jaune') || name.includes('blanc')) {
+        return AlertSeverity.MODERATE;
+    }
+    if (name.includes('vert') || name.includes('bleu')) {
+        return AlertSeverity.MINOR;
+    }
+    return AlertSeverity.UNKNOWN;
 }
 
 /** Overseas territories are not served by `v3/warning/full`, they have their own `VIGI*` domain. */

--- a/app/services/providers/owm.ts
+++ b/app/services/providers/owm.ts
@@ -5,10 +5,10 @@ import { WeatherDataType, weatherDataIconColors } from '~/helpers/formatter';
 import { getStartOfDay, lang } from '~/helpers/locale';
 import { WeatherLocation, request } from '../api';
 import { prefs } from '../preferences';
-import { normalizeOwmAlerts } from './alerts';
 import { CityWeather, Coord, OneCallResult } from './openweathermap';
-import { Currently, DailyData, Hourly, WeatherData } from './weather';
-import { WeatherProvider } from './weatherprovider';
+import { buildOwmAlerts } from './owmAlerts';
+import { Alert, Currently, DailyData, Hourly, WeatherData } from './weather';
+import { GetWeatherOptions, WeatherProvider } from './weatherprovider';
 
 const API_KEY_SETTING = 'owmApiKey';
 
@@ -61,11 +61,25 @@ export class OWMProvider extends WeatherProvider {
         });
     }
 
+    private static fetchOneCall(coords: Coord) {
+        const onecallVersion = ApplicationSettings.getString('owm_one_call_version', '3.0');
+        return OWMProvider.fetch<OneCallResult>(onecallVersion, 'onecall', coords);
+    }
+
+    /**
+     * One Call ships the alerts along with the forecast.
+     *
+     * @param onecall the payload when `getWeather` already fetched it
+     */
+    public override async getAlerts(weatherLocation: WeatherLocation, options?: GetWeatherOptions, onecall?: OneCallResult): Promise<Alert[]> {
+        const forecast = onecall ?? (await OWMProvider.fetchOneCall(weatherLocation.coord))?.content;
+        return buildOwmAlerts(forecast?.alerts);
+    }
+
     public override async getWeather(weatherLocation: WeatherLocation, { current, minutely, warnings }: { warnings?: boolean; minutely?: boolean; current?: boolean } = {}) {
         const coords = weatherLocation.coord;
         const feelsLikeTemperatures = ApplicationSettings.getBoolean('feels_like_temperatures', FEELS_LIKE_TEMPERATURE);
-        const onecallVersion = ApplicationSettings.getString('owm_one_call_version', '3.0');
-        const result = await OWMProvider.fetch<OneCallResult>(onecallVersion, 'onecall', coords);
+        const result = await OWMProvider.fetchOneCall(coords);
         const forecast = result.content;
         const forecast_days = ApplicationSettings.getNumber('forecast_nb_days', NB_DAYS_FORECAST);
         const forecast_hours = ApplicationSettings.getNumber('forecast_nb_hours', NB_HOURS_FORECAST);
@@ -136,7 +150,7 @@ export class OWMProvider extends WeatherProvider {
                         }))
                         .filter((d, i) => i % 5 === 0) || []
             },
-            alerts: normalizeOwmAlerts(forecast.alerts)
+            alerts: warnings !== false ? await this.getAlerts(weatherLocation, { warnings }, forecast) : []
         } as WeatherData;
         if (forecast.hourly) {
             const hourlyLastIndex = Math.min(forecast.hourly.length, forecast_hours) - 1;

--- a/app/services/providers/owmAlerts.test.ts
+++ b/app/services/providers/owmAlerts.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { buildOwmAlerts } from './owmAlerts';
+
+describe('buildOwmAlerts', () => {
+    // One Call returns `start`/`end` as Unix seconds, the app works in milliseconds.
+    const OWM_ALERT = {
+        sender_name: 'Météo-France',
+        event: 'Canicule',
+        start: 1786380000,
+        end: 1786410000,
+        description: 'Vigilance orange canicule',
+        tags: ['Extreme high temperature']
+    };
+
+    it('converts seconds to milliseconds', () => {
+        const [alert] = buildOwmAlerts([OWM_ALERT]);
+        expect(alert.start).toBe(1786380000000);
+        expect(alert.end).toBe(1786410000000);
+    });
+
+    it('keeps the sender, event and description', () => {
+        const [alert] = buildOwmAlerts([OWM_ALERT]);
+        expect(alert.sender_name).toBe('Météo-France');
+        expect(alert.event).toBe('Canicule');
+        expect(alert.description).toBe('Vigilance orange canicule');
+    });
+
+    it('handles a missing alerts array', () => {
+        expect(buildOwmAlerts(undefined)).toEqual([]);
+    });
+});

--- a/app/services/providers/owmAlerts.ts
+++ b/app/services/providers/owmAlerts.ts
@@ -1,0 +1,23 @@
+import { AlertSeverity } from './alerts';
+import type { Alert as OWMAlert } from './openweathermap';
+import type { Alert } from './weather';
+
+/**
+ * One Call alert mapping. Kept out of `owm.ts` so it stays unit testable.
+ *
+ * One Call gives `start`/`end` in seconds and no severity.
+ */
+export function buildOwmAlerts(alerts: OWMAlert[]): Alert[] {
+    if (!alerts?.length) {
+        return [];
+    }
+    return alerts.map((alert) => ({
+        sender_name: alert.sender_name,
+        event: alert.event,
+        start: alert.start * 1000,
+        end: alert.end * 1000,
+        description: alert.description,
+        tags: alert.tags,
+        severity: AlertSeverity.UNKNOWN
+    }));
+}

--- a/app/services/providers/weatherprovider.ts
+++ b/app/services/providers/weatherprovider.ts
@@ -1,7 +1,7 @@
 import { WeatherLocation } from '../api';
 import { WeatherProps } from '../weatherData';
 import { Provider } from './provider';
-import { AirQualityData, WeatherData } from './weather';
+import { AirQualityData, Alert, WeatherData } from './weather';
 
 export interface GetWeatherOptions {
     model?: string;
@@ -14,6 +14,16 @@ export interface GetWeatherOptions {
 }
 export abstract class WeatherProvider extends Provider {
     abstract getWeather(weatherLocation: WeatherLocation, options?: GetWeatherOptions): Promise<WeatherData>;
+    /**
+     * Weather alerts for that location, called by `getWeather`. A provider owns both the request
+     * and the mapping of its own payload; the ones without an alert API keep this default.
+     *
+     * A provider whose alerts come from a payload `getWeather` already fetched takes it as a third
+     * argument, so calling `getAlerts` on its own stays possible without requesting it twice.
+     */
+    getAlerts(weatherLocation: WeatherLocation, options?: GetWeatherOptions): Promise<Alert[]> {
+        return Promise.resolve([]);
+    }
     getModels() {
         return {};
     }


### PR DESCRIPTION
## Summary

- `WeatherProvider` now declares **`getAlerts()`**, empty by default, and each provider overrides it with its own request and its own mapping. `getWeather` just calls it. Open-Meteo, which has no alert API, inherits the default instead of hardcoding `alerts: []`.
- **`alerts.ts` no longer knows any provider.** It keeps only `AlertSeverity`, `colorFromSeverity`, `hexFromChannels` and `sortAlerts`. The OpenWeather and AccuWeather mappings move to `owmAlerts.ts` / `accuAlerts.ts`, and the vigilance severity helpers (color ids, French color names) move to `mfWarnings.ts` where they belong.
- Météo France and OpenWeather read their alerts from a payload `getWeather` has already fetched (the `v2/forecast` department, the One Call response), so they take it as an optional third argument. Calling `getAlerts()` on its own still works — it fetches what it needs — without ever requesting it twice from `getWeather`.

No behavior change: same requests, same alerts, same rendering.

## Testing

`npx vitest run app` — 31 passing. The existing tests moved next to the code they cover (`owmAlerts.test.ts`, `accuAlerts.test.ts`), `alerts.test.ts` keeps the provider-agnostic ones, plus a new case on `hexFromChannels`. `yarn svelte-check` reports no new error, `npx eslint` and Prettier are clean.

Being a pure refactor with the alert behavior already covered by tests, no device pass is required beyond the one already done on #494.