### PR TITLE
fix(map): resolve browser exports so the map bundle builds

### DIFF
--- a/map/webpack.config.js
+++ b/map/webpack.config.js
@@ -31,7 +31,10 @@ module.exports = (env = {}, params = {}) => {
         entry: ENTRY,
         stats: 'none',
         resolve: {
-            conditionNames: ['svelte', 'import', 'require', 'node', 'default'],
+            // 'browser' (not 'node'): this bundle targets a WebView. With 'node' active,
+            // packages like uuid resolve their `node` export (which imports `node:crypto`)
+            // and webpack fails with UnhandledSchemeError.
+            conditionNames: ['svelte', 'browser', 'import', 'require', 'default'],
             alias: {
                 // svelte: path.resolve(__dirname, '../node_modules/svelte')
             },


### PR DESCRIPTION
## Summary

- `ns prepare ios` (and any prepare, since `buildweathermap` defaults to `true`) failed with `UnhandledSchemeError: Reading from "node:crypto" is not handled by plugins`.
- Cause: `map/webpack.config.js` listed `node` in `resolve.conditionNames`, so `uuid` (a transitive dep of `@maptiler/sdk`) resolved its `node` export — `dist-node`, which imports `node:crypto`. The `exports` key order decides which condition wins, so the existing `mainFields: ['svelte', 'browser', ...]` never got a say.
- Swap `node` for `browser` in `conditionNames`. This bundle targets a WebView, so `browser` is the correct condition; `uuid`'s browser build has no `node:` imports (pure-JS md5/sha1, `crypto.getRandomValues` for v4).

## Testing

- Map bundle with the fix stashed: fails with `ERROR in node:crypto`, exit 1. With the fix: exit 0. Same webpack binary the root config uses (5.107.2).
- Full `ns prepare ios` — no `--env.buildweathermap=0` — ends in `Project successfully prepared (ios)`, with only the pre-existing Sass `@import` deprecation and unused-Svelte-export warnings. Built bundle contains no `node:` references.
- `prettier --check` passes. `eslint` cannot lint this file (`that TSConfig does not include this file`) — path-based and pre-existing, unrelated to the change.
- **Still needs a visual check**: the map screen has not been exercised on a device, only built.

## Note for the reviewer

While verifying, the first `ns prepare ios` left a *stale* map bundle in `platforms/ios/` — the map compiler and the root compiler run in parallel from `app.webpack.config.js:814`, and `WaitPlugin` only guards `env.adhoc` / `env.adhoc_sentry`. A second prepare synced them. Pre-existing race, left untouched here.